### PR TITLE
Backport fixes from master to 0.9.7+x.

### DIFF
--- a/benchmark/path_set.dart
+++ b/benchmark/path_set.dart
@@ -1,0 +1,147 @@
+// Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Benchmarks for the PathSet class.
+library watcher.benchmark.path_set;
+
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:benchmark_harness/benchmark_harness.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:watcher/src/path_set.dart';
+
+final String root = Platform.isWindows ? r"C:\root" : "/root";
+
+/// Base class for benchmarks on [PathSet].
+abstract class PathSetBenchmark extends BenchmarkBase {
+  PathSetBenchmark(String method) : super("PathSet.$method");
+
+  final PathSet pathSet = new PathSet(root);
+
+  /// Use a fixed [Random] with a constant seed to ensure the tests are
+  /// deterministic.
+  final math.Random random = new math.Random(1234);
+
+  /// Walks over a virtual directory [depth] levels deep invoking [callback]
+  /// for each "file".
+  ///
+  /// Each virtual directory contains ten entries: either subdirectories or
+  /// files.
+  void walkTree(int depth, callback(String path)) {
+    recurse(path, remainingDepth) {
+      for (var i = 0; i < 10; i++) {
+        var padded = i.toString().padLeft(2, '0');
+        if (remainingDepth == 0) {
+          callback(p.join(path, "file_$padded.txt"));
+        } else {
+          var subdir = p.join(path, "subdirectory_$padded");
+          recurse(subdir, remainingDepth - 1);
+        }
+      }
+    }
+
+    recurse(root, depth);
+  }
+}
+
+class AddBenchmark extends PathSetBenchmark {
+  AddBenchmark() : super("add()");
+
+  final List<String> paths = [];
+
+  void setup() {
+    // Make a bunch of paths in about the same order we expect to get them from
+    // Directory.list().
+    walkTree(3, paths.add);
+  }
+
+  void run() {
+    for (var path in paths) pathSet.add(path);
+  }
+}
+
+class ContainsBenchmark extends PathSetBenchmark {
+  ContainsBenchmark() : super("contains()");
+
+  final List<String> paths = [];
+
+  void setup() {
+    // Add a bunch of paths to the set.
+    walkTree(3, (path) {
+      pathSet.add(path);
+      paths.add(path);
+    });
+
+    // Add some non-existent paths to test the false case.
+    for (var i = 0; i < 100; i++) {
+      paths.addAll([
+        "/nope",
+        "/root/nope",
+        "/root/subdirectory_04/nope",
+        "/root/subdirectory_04/subdirectory_04/nope",
+        "/root/subdirectory_04/subdirectory_04/subdirectory_04/nope",
+        "/root/subdirectory_04/subdirectory_04/subdirectory_04/nope/file_04.txt",
+      ]);
+    }
+  }
+
+  void run() {
+    var contained = 0;
+    for (var path in paths) {
+      if (pathSet.contains(path)) contained++;
+    }
+
+    if (contained != 10000) throw "Wrong result: $contained";
+  }
+}
+
+class PathsBenchmark extends PathSetBenchmark {
+  PathsBenchmark() : super("toSet()");
+
+  void setup() {
+    walkTree(3, pathSet.add);
+  }
+
+  void run() {
+    var count = 0;
+    for (var _ in pathSet.paths) {
+      count++;
+    }
+
+    if (count != 10000) throw "Wrong result: $count";
+  }
+}
+
+class RemoveBenchmark extends PathSetBenchmark {
+  RemoveBenchmark() : super("remove()");
+
+  final List<String> paths = [];
+
+  void setup() {
+    // Make a bunch of paths. Do this here so that we don't spend benchmarked
+    // time synthesizing paths.
+    walkTree(3, (path) {
+      pathSet.add(path);
+      paths.add(path);
+    });
+
+    // Shuffle the paths so that we delete them in a random order that
+    // hopefully mimics real-world file system usage. Do the shuffling here so
+    // that we don't spend benchmarked time shuffling.
+    paths.shuffle(random);
+  }
+
+  void run() {
+    for (var path in paths) pathSet.remove(path);
+  }
+}
+
+main() {
+  new AddBenchmark().report();
+  new ContainsBenchmark().report();
+  new PathsBenchmark().report();
+  new RemoveBenchmark().report();
+}

--- a/lib/src/async_queue.dart
+++ b/lib/src/async_queue.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.async_queue;
-
 import 'dart:async';
 import 'dart:collection';
 

--- a/lib/src/constructable_file_system_event.dart
+++ b/lib/src/constructable_file_system_event.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.constructable_file_system_event;
-
 import 'dart:io';
 
 abstract class _ConstructableFileSystemEvent implements FileSystemEvent {

--- a/lib/src/directory_watcher.dart
+++ b/lib/src/directory_watcher.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.directory_watcher;
-
 import 'dart:io';
 
-import 'watch_event.dart';
 import '../watcher.dart';
 import 'directory_watcher/linux.dart';
 import 'directory_watcher/mac_os.dart';

--- a/lib/src/directory_watcher/linux.dart
+++ b/lib/src/directory_watcher/linux.dart
@@ -2,12 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.directory_watcher.linux;
-
 import 'dart:async';
 import 'dart:io';
 
+import 'package:async/async.dart';
+
 import '../directory_watcher.dart';
+import '../path_set.dart';
 import '../resubscribable.dart';
 import '../utils.dart';
 import '../watch_event.dart';
@@ -32,8 +33,8 @@ class LinuxDirectoryWatcher extends ResubscribableWatcher
 
 class _LinuxDirectoryWatcher
     implements DirectoryWatcher, ManuallyClosedWatcher {
-  String get directory => path;
-  final String path;
+  String get directory => _files.root;
+  String get path => _files.root;
 
   Stream<WatchEvent> get events => _eventsController.stream;
   final _eventsController = new StreamController<WatchEvent>.broadcast();
@@ -43,15 +44,17 @@ class _LinuxDirectoryWatcher
   Future get ready => _readyCompleter.future;
   final _readyCompleter = new Completer();
 
-  /// The last known state for each entry in this directory.
-  ///
-  /// The keys in this map are the paths to the directory entries; the values
-  /// are [_EntryState]s indicating whether the entries are files or
-  /// directories.
-  final _entries = new Map<String, _EntryState>();
+  /// A stream group for the [Directory.watch] events of [path] and all its
+  /// subdirectories.
+  var _nativeEvents = new StreamGroup<FileSystemEvent>();
 
-  /// The watchers for subdirectories of [directory].
-  final _subWatchers = new Map<String, _LinuxDirectoryWatcher>();
+  /// All known files recursively within [path].
+  final PathSet _files;
+
+  /// [Directory.watch] streams for [path]'s subdirectories, indexed by name.
+  ///
+  /// A stream is in this map if and only if it's also in [_nativeEvents].
+  final _subdirStreams = <String, Stream<FileSystemEvent>>{};
 
   /// A set of all subscriptions that this watcher subscribes to.
   ///
@@ -59,93 +62,51 @@ class _LinuxDirectoryWatcher
   /// watcher is closed.
   final _subscriptions = new Set<StreamSubscription>();
 
-  _LinuxDirectoryWatcher(this.path) {
+  _LinuxDirectoryWatcher(String path)
+      : _files = new PathSet(path) {
+    _nativeEvents.add(new Directory(path).watch().transform(
+        new StreamTransformer.fromHandlers(handleDone: (sink) {
+      // Once the root directory is deleted, no more new subdirectories will be
+      // watched.
+      _nativeEvents.close();
+      sink.close();
+    })));
+
     // Batch the inotify changes together so that we can dedup events.
-    var innerStream = new Directory(path).watch()
+    var innerStream = _nativeEvents.stream
         .transform(new BatchedStreamTransformer<FileSystemEvent>());
     _listen(innerStream, _onBatch,
         onError: _eventsController.addError,
         onDone: _onDone);
 
-    _listen(new Directory(path).list(), (entity) {
-      _entries[entity.path] = new _EntryState(entity is Directory);
-      if (entity is! Directory) return;
-      _watchSubdir(entity.path);
+    _listen(new Directory(path).list(recursive: true), (entity) {
+      if (entity is Directory) {
+        _watchSubdir(entity.path);
+      } else {
+        _files.add(entity.path);
+      }
     }, onError: (error, stackTrace) {
       _eventsController.addError(error, stackTrace);
       close();
     }, onDone: () {
-      _waitUntilReady().then((_) => _readyCompleter.complete());
+      _readyCompleter.complete();
     }, cancelOnError: true);
-  }
-
-  /// Returns a [Future] that completes once all the subdirectory watchers are
-  /// fully initialized.
-  Future _waitUntilReady() {
-    return Future.wait(_subWatchers.values.map((watcher) => watcher.ready))
-        .then((_) {
-      if (_subWatchers.values.every((watcher) => watcher.isReady)) return null;
-      return _waitUntilReady();
-    });
   }
 
   void close() {
     for (var subscription in _subscriptions) {
       subscription.cancel();
     }
-    for (var watcher in _subWatchers.values) {
-      watcher.close();
-    }
 
-    _subWatchers.clear();
     _subscriptions.clear();
+    _subdirStreams.clear();
+    _files.clear();
+    _nativeEvents.close();
     _eventsController.close();
   }
 
-  /// Returns all files (not directories) that this watcher knows of are
-  /// recursively in the watched directory.
-  Set<String> get _allFiles {
-    var files = new Set<String>();
-    _getAllFiles(files);
-    return files;
-  }
-
-  /// Helper function for [_allFiles].
-  ///
-  /// Adds all files that this watcher knows of to [files].
-  void _getAllFiles(Set<String> files) {
-    files.addAll(_entries.keys
-        .where((path) => _entries[path] == _EntryState.FILE).toSet());
-    for (var watcher in _subWatchers.values) {
-      watcher._getAllFiles(files);
-    }
-  }
-
   /// Watch a subdirectory of [directory] for changes.
-  ///
-  /// If the subdirectory was added after [this] began emitting events, its
-  /// contents will be emitted as ADD events.
   void _watchSubdir(String path) {
-    if (_subWatchers.containsKey(path)) return;
-    var watcher = new _LinuxDirectoryWatcher(path);
-    _subWatchers[path] = watcher;
-
-    // TODO(nweiz): Catch any errors here that indicate that the directory in
-    // question doesn't exist and silently stop watching it instead of
-    // propagating the errors.
-    _listen(watcher.events, (event) {
-      if (isReady) _eventsController.add(event);
-    }, onError: (error, stackTrace) {
-      _eventsController.addError(error, stackTrace);
-      close();
-    }, onDone: () {
-      if (_subWatchers[path] == watcher) _subWatchers.remove(path);
-
-      // It's possible that a directory was removed and recreated very quickly.
-      // If so, make sure we're still watching it.
-      if (new Directory(path).existsSync()) _watchSubdir(path);
-    });
-
     // TODO(nweiz): Right now it's possible for the watcher to emit an event for
     // a file before the directory list is complete. This could lead to the user
     // seeing a MODIFY or REMOVE event for a file before they see an ADD event,
@@ -157,96 +118,110 @@ class _LinuxDirectoryWatcher
     // top-level clients such as barback as well, and could be implemented with
     // a wrapper similar to how listening/canceling works now.
 
-    // If a directory is added after we're finished with the initial scan, emit
-    // an event for each entry in it. This gives the user consistently gets an
-    // event for every new file.
-    watcher.ready.then((_) {
-      if (!isReady || _eventsController.isClosed) return;
-      _listen(new Directory(path).list(recursive: true), (entry) {
-        if (entry is Directory) return;
-        _eventsController.add(new WatchEvent(ChangeType.ADD, entry.path));
-      }, onError: (error, stackTrace) {
-        // Ignore an exception caused by the dir not existing. It's fine if it
-        // was added and then quickly removed.
-        if (error is FileSystemException) return;
-
-        _eventsController.addError(error, stackTrace);
-        close();
-      }, cancelOnError: true);
-    });
+    // TODO(nweiz): Catch any errors here that indicate that the directory in
+    // question doesn't exist and silently stop watching it instead of
+    // propagating the errors.
+    var stream = new Directory(path).watch();
+    _subdirStreams[path] = stream;
+    _nativeEvents.add(stream);
   }
 
   /// The callback that's run when a batch of changes comes in.
   void _onBatch(List<FileSystemEvent> batch) {
-    var changedEntries = new Set<String>();
-    var oldEntries = new Map.from(_entries);
+    var files = new Set();
+    var dirs = new Set();
+    var changed = new Set();
 
     // inotify event batches are ordered by occurrence, so we treat them as a
-    // log of what happened to a file.
+    // log of what happened to a file. We only emit events based on the
+    // difference between the state before the batch and the state after it, not
+    // the intermediate state.
     for (var event in batch) {
       // If the watched directory is deleted or moved, we'll get a deletion
       // event for it. Ignore it; we handle closing [this] when the underlying
       // stream is closed.
       if (event.path == path) continue;
 
-      changedEntries.add(event.path);
+      changed.add(event.path);
 
       if (event is FileSystemMoveEvent) {
-        changedEntries.add(event.destination);
-        _changeEntryState(event.path, ChangeType.REMOVE, event.isDirectory);
-        _changeEntryState(event.destination, ChangeType.ADD, event.isDirectory);
-      } else {
-        _changeEntryState(event.path, _changeTypeFor(event), event.isDirectory);
-      }
-    }
+        files.remove(event.path);
+        dirs.remove(event.path);
 
-    for (var path in changedEntries) {
-      emitEvent(ChangeType type) {
-        if (isReady) _eventsController.add(new WatchEvent(type, path));
-      }
-
-      var oldState = oldEntries[path];
-      var newState = _entries[path];
-
-      if (oldState != _EntryState.FILE && newState == _EntryState.FILE) {
-        emitEvent(ChangeType.ADD);
-      } else if (oldState == _EntryState.FILE && newState == _EntryState.FILE) {
-        emitEvent(ChangeType.MODIFY);
-      } else if (oldState == _EntryState.FILE && newState != _EntryState.FILE) {
-        emitEvent(ChangeType.REMOVE);
-      }
-
-      if (oldState == _EntryState.DIRECTORY) {
-        var watcher = _subWatchers.remove(path);
-        if (watcher == null) continue;
-        for (var path in watcher._allFiles) {
-          _eventsController.add(new WatchEvent(ChangeType.REMOVE, path));
+        changed.add(event.destination);
+        if (event.isDirectory) {
+          files.remove(event.destination);
+          dirs.add(event.destination);
+        } else {
+          files.add(event.destination);
+          dirs.remove(event.destination);
         }
-        watcher.close();
+      } else if (event is FileSystemDeleteEvent) {
+        files.remove(event.path);
+        dirs.remove(event.path);
+      } else if (event.isDirectory) {
+        files.remove(event.path);
+        dirs.add(event.path);
+      } else {
+        files.add(event.path);
+        dirs.remove(event.path);
       }
+    }
 
-      if (newState == _EntryState.DIRECTORY) _watchSubdir(path);
+    _applyChanges(files, dirs, changed);
+  }
+
+  /// Applies the net changes computed for a batch.
+  ///
+  /// The [files] and [dirs] sets contain the files and directories that now
+  /// exist, respectively. The [changed] set contains all files and directories
+  /// that have changed (including being removed), and so is a superset of
+  /// [files] and [dirs].
+  void _applyChanges(Set<String> files, Set<String> dirs, Set<String> changed) {
+    for (var path in changed) {
+      var stream = _subdirStreams.remove(path);
+      if (stream != null) _nativeEvents.add(stream);
+
+      // Unless [path] was a file and still is, emit REMOVE events for it or its
+      // contents,
+      if (files.contains(path) && _files.contains(path)) continue;
+      for (var file in _files.remove(path)) {
+        _emit(ChangeType.REMOVE, file);
+      }
+    }
+
+    for (var file in files) {
+      if (_files.contains(file)) {
+        _emit(ChangeType.MODIFY, file);
+      } else {
+        _emit(ChangeType.ADD, file);
+        _files.add(file);
+      }
+    }
+
+    for (var dir in dirs) {
+      _watchSubdir(dir);
+      _addSubdir(dir);
     }
   }
 
-  /// Changes the known state of the entry at [path] based on [change] and
-  /// [isDir].
-  void _changeEntryState(String path, ChangeType change, bool isDir) {
-    if (change == ChangeType.ADD || change == ChangeType.MODIFY) {
-      _entries[path] = new _EntryState(isDir);
-    } else {
-      assert(change == ChangeType.REMOVE);
-      _entries.remove(path);
-    }
-  }
+  /// Emits [ChangeType.ADD] events for the recursive contents of [path].
+  void _addSubdir(String path) {
+    _listen(new Directory(path).list(recursive: true), (entity) {
+      if (entity is Directory) {
+        _watchSubdir(entity.path);
+      } else {
+        _files.add(entity.path);
+        _emit(ChangeType.ADD, entity.path);
+      }
+    }, onError: (error, stackTrace) {
+      // Ignore an exception caused by the dir not existing. It's fine if it
+      // was added and then quickly removed.
+      if (error is FileSystemException) return;
 
-  /// Determines the [ChangeType] associated with [event].
-  ChangeType _changeTypeFor(FileSystemEvent event) {
-    if (event is FileSystemDeleteEvent) return ChangeType.REMOVE;
-    if (event is FileSystemCreateEvent) return ChangeType.ADD;
-
-    assert(event is FileSystemModifyEvent);
-    return ChangeType.MODIFY;
+      _eventsController.addError(error, stackTrace);
+      close();
+    }, cancelOnError: true);
   }
 
   /// Handles the underlying event stream closing, indicating that the directory
@@ -254,28 +229,23 @@ class _LinuxDirectoryWatcher
   void _onDone() {
     // Most of the time when a directory is removed, its contents will get
     // individual REMOVE events before the watch stream is closed -- in that
-    // case, [_entries] will be empty here. However, if the directory's removal
-    // is caused by a MOVE, we need to manually emit events.
+    // case, [_files] will be empty here. However, if the directory's removal is
+    // caused by a MOVE, we need to manually emit events.
     if (isReady) {
-      _entries.forEach((path, state) {
-        if (state == _EntryState.DIRECTORY) return;
-        _eventsController.add(new WatchEvent(ChangeType.REMOVE, path));
-      });
+      for (var file in _files.paths) {
+        _emit(ChangeType.REMOVE, file);
+      }
     }
 
-    // The parent directory often gets a close event before the subdirectories
-    // are done emitting events. We wait for them to finish before we close
-    // [events] so that we can be sure to emit a remove event for every file
-    // that used to exist.
-    Future.wait(_subWatchers.values.map((watcher) {
-      try {
-        return watcher.events.toList();
-      } on StateError catch (_) {
-        // It's possible that [watcher.events] is closed but the onDone event
-        // hasn't reached us yet. It's fine if so.
-        return new Future.value();
-      }
-    })).then((_) => close());
+    close();
+  }
+
+  /// Emits a [WatchEvent] with [type] and [path] if this watcher is in a state
+  /// to emit events.
+  void _emit(ChangeType type, String path) {
+    if (!isReady) return;
+    if (_eventsController.isClosed) return;
+    _eventsController.add(new WatchEvent(type, path));
   }
 
   /// Like [Stream.listen], but automatically adds the subscription to
@@ -289,23 +259,4 @@ class _LinuxDirectoryWatcher
     }, cancelOnError: cancelOnError);
     _subscriptions.add(subscription);
   }
-}
-
-/// An enum for the possible states of entries in a watched directory.
-class _EntryState {
-  final String _name;
-
-  /// The entry is a file.
-  static const FILE = const _EntryState._("file");
-
-  /// The entry is a directory.
-  static const DIRECTORY = const _EntryState._("directory");
-
-  const _EntryState._(this._name);
-
-  /// Returns [DIRECTORY] if [isDir] is true, and [FILE] otherwise.
-  factory _EntryState(bool isDir) =>
-      isDir ? _EntryState.DIRECTORY : _EntryState.FILE;
-
-  String toString() => _name;
 }

--- a/lib/src/directory_watcher/polling.dart
+++ b/lib/src/directory_watcher/polling.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.directory_watcher.polling;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/file_watcher.dart
+++ b/lib/src/file_watcher.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.file_watcher;
-
 import 'dart:io';
 
-import 'watch_event.dart';
 import '../watcher.dart';
 import 'file_watcher/native.dart';
 import 'file_watcher/polling.dart';

--- a/lib/src/file_watcher/native.dart
+++ b/lib/src/file_watcher/native.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.file_watcher.native;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/file_watcher/polling.dart
+++ b/lib/src/file_watcher/polling.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.file_watcher.polling;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/resubscribable.dart
+++ b/lib/src/resubscribable.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.resubscribable;
-
 import 'dart:async';
 
 import '../watcher.dart';

--- a/lib/src/stat.dart
+++ b/lib/src/stat.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.stat;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.utils;
-
 import 'dart:async';
 import 'dart:io';
 import 'dart:collection';
@@ -33,7 +31,7 @@ Set unionAll(Iterable<Set> sets) =>
 /// [broadcast] defaults to false.
 Stream futureStream(Future<Stream> future, {bool broadcast: false}) {
   var subscription;
-  var controller;
+  StreamController controller;
 
   future = future.catchError((e, stackTrace) {
     // Since [controller] is synchronous, it's likely that emitting an error
@@ -94,7 +92,7 @@ Future pumpEventQueue([int times = 20]) {
 /// microtasks.
 class BatchedStreamTransformer<T> implements StreamTransformer<T, List<T>> {
   Stream<List<T>> bind(Stream<T> input) {
-    var batch = new Queue();
+    var batch = new Queue<T>();
     return new StreamTransformer<T, List<T>>.fromHandlers(
         handleData: (event, sink) {
       batch.add(event);

--- a/lib/src/watch_event.dart
+++ b/lib/src/watch_event.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.watch_event;
-
 /// An event describing a single change to the file system.
 class WatchEvent {
   /// The manner in which the file at [path] has changed.

--- a/lib/watcher.dart
+++ b/lib/watcher.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher;
-
 import 'dart:async';
 import 'dart:io';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,17 @@
 name: watcher
-version: 0.9.7
+version: 0.9.8-dev
 author: Dart Team <misc@dartlang.org>
-homepage: http://github.com/dart-lang/watcher
+homepage: https://github.com/dart-lang/watcher
 description: >
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.
 environment:
   sdk: '>=1.9.0 <2.0.0'
 dependencies:
+  async: '^1.2.0'
+  collection: '^1.0.0'
   path: '>=0.9.0 <2.0.0'
 dev_dependencies:
+  benchmark_harness: '^1.0.4'
   scheduled_test: '^0.12.0'
   test: '^0.12.0'

--- a/test/directory_watcher/shared.dart
+++ b/test/directory_watcher/shared.dart
@@ -246,6 +246,37 @@ void sharedTests() {
       expectModifyEvent("new/file.txt");
     });
 
+    test('notifies when a file is replaced by a subdirectory', () {
+      writeFile("new");
+      writeFile("old/file.txt");
+      startWatcher();
+
+      deleteFile("new");
+      renameDir("old", "new");
+      inAnyOrder([
+        isRemoveEvent("new"),
+        isRemoveEvent("old/file.txt"),
+        isAddEvent("new/file.txt")
+      ]);
+    });
+
+    test('notifies when a subdirectory is replaced by a file', () {
+      writeFile("old");
+      writeFile("new/file.txt");
+      startWatcher();
+
+      renameDir("new", "newer");
+      renameFile("old", "new");
+      inAnyOrder([
+        isRemoveEvent("new/file.txt"),
+        isAddEvent("newer/file.txt"),
+        isRemoveEvent("old"),
+        isAddEvent("new")
+      ]);
+    }, onPlatform: {
+      "mac-os": new Skip("https://github.com/dart-lang/watcher/issues/21")
+    });
+
     test('emits events for many nested files added at once', () {
       withPermutations((i, j, k) =>
           writeFile("sub/sub-$i/sub-$j/file-$k.txt"));

--- a/test/file_watcher/native_test.dart
+++ b/test/file_watcher/native_test.dart
@@ -6,7 +6,6 @@
 
 import 'package:scheduled_test/scheduled_test.dart';
 import 'package:watcher/src/file_watcher/native.dart';
-import 'package:watcher/watcher.dart';
 
 import 'shared.dart';
 import '../utils.dart';

--- a/test/no_subscription/mac_os_test.dart
+++ b/test/no_subscription/mac_os_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('mac-os')
+@Skip("Flaky due to sdk#23877")
 
 import 'package:scheduled_test/scheduled_test.dart';
 import 'package:watcher/src/directory_watcher/mac_os.dart';

--- a/test/path_set_test.dart
+++ b/test/path_set_test.dart
@@ -6,8 +6,6 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 import 'package:watcher/src/path_set.dart';
 
-import 'utils.dart';
-
 Matcher containsPath(String path) => predicate((set) =>
     set is PathSet && set.contains(path),
     'set contains "$path"');
@@ -42,10 +40,6 @@ void main() {
       set.add(p.absolute("root/path/to/file"));
       expect(set, containsPath("root/path/to/file"));
     });
-
-    test("that's not beneath the root throws an error", () {
-      expect(() => set.add("path/to/file"), throwsArgumentError);
-    });
   });
 
   group("removing a path", () {
@@ -78,7 +72,7 @@ void main() {
       expect(set, isNot(containsPath("root/path/to/two")));
       expect(set, isNot(containsPath("root/path/to/sub/three")));
     });
-  
+
     test("that's a directory in the set removes and returns it and all files "
         "beneath it", () {
       set.add("root/path");
@@ -110,10 +104,6 @@ void main() {
       expect(set.remove(p.absolute("root/path/to/file")),
           unorderedEquals([p.normalize("root/path/to/file")]));
     });
-
-    test("that's not beneath the root throws an error", () {
-      expect(() => set.remove("path/to/file"), throwsArgumentError);
-    });
   });
 
   group("containsPath()", () {
@@ -142,10 +132,6 @@ void main() {
     test("with an absolute path normalizes the path before looking it up", () {
       set.add("root/path/to/file");
       expect(set, containsPath(p.absolute("root/path/to/file")));
-    });
-
-    test("with a path that's not beneath the root throws an error", () {
-      expect(() => set.contains("path/to/file"), throwsArgumentError);
     });
   });
 
@@ -198,13 +184,13 @@ void main() {
     });
   });
 
-  group("toSet", () {
+  group("paths", () {
     test("returns paths added to the set", () {
       set.add("root/path");
       set.add("root/path/to/one");
       set.add("root/path/to/two");
 
-      expect(set.toSet(), unorderedEquals([
+      expect(set.paths, unorderedEquals([
         "root/path",
         "root/path/to/one",
         "root/path/to/two",
@@ -216,7 +202,7 @@ void main() {
       set.add("root/path/to/two");
       set.remove("root/path/to/two");
 
-      expect(set.toSet(), unorderedEquals([p.normalize("root/path/to/one")]));
+      expect(set.paths, unorderedEquals([p.normalize("root/path/to/one")]));
     });
   });
 
@@ -227,7 +213,7 @@ void main() {
       set.add("root/path/to/two");
 
       set.clear();
-      expect(set.toSet(), isEmpty);
+      expect(set.paths, isEmpty);
     });
   });
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-library watcher.test.utils;
-
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -12,9 +10,6 @@ import 'package:scheduled_test/scheduled_test.dart';
 import 'package:watcher/watcher.dart';
 import 'package:watcher/src/stat.dart';
 import 'package:watcher/src/utils.dart';
-
-// TODO(nweiz): remove this when issue 15042 is fixed.
-import 'package:watcher/src/directory_watcher/mac_os.dart';
 
 /// The path to the temporary sandbox created for each test. All file
 /// operations are implicitly relative to this directory.
@@ -292,7 +287,7 @@ void writeFile(String path, {String contents, bool updateModified}) {
       // Make sure we always use the same separator on Windows.
       path = p.normalize(path);
 
-      var milliseconds = _mockFileModificationTimes.putIfAbsent(path, () => 0);
+      _mockFileModificationTimes.putIfAbsent(path, () => 0);
       _mockFileModificationTimes[path]++;
     }
   }, "write file $path");
@@ -316,7 +311,7 @@ void renameFile(String from, String to) {
     to = p.normalize(to);
 
     // Manually update the mock modification time for the file.
-    var milliseconds = _mockFileModificationTimes.putIfAbsent(to, () => 0);
+    _mockFileModificationTimes.putIfAbsent(to, () => 0);
     _mockFileModificationTimes[to]++;
   }, "rename file $from to $to");
 }
@@ -349,9 +344,10 @@ void deleteDir(String path) {
 /// Returns a set of all values returns by [callback].
 ///
 /// [limit] defaults to 3.
-Set withPermutations(callback(int i, int j, int k), {int limit}) {
+Set/*<S>*/ withPermutations/*<S>*/(/*=S*/ callback(int i, int j, int k),
+    {int limit}) {
   if (limit == null) limit = 3;
-  var results = new Set();
+  var results = new Set/*<S>*/();
   for (var i = 0; i < limit; i++) {
     for (var j = 0; j < limit; j++) {
       for (var k = 0; k < limit; k++) {


### PR DESCRIPTION
Master contains a partial implementation of new symlink logic that's not ready to release, but we need to cut a release with analysis fixes and speed increases before we'll have time to fully implement it. I've created an 0.9.7+x branch, and this backports the non-symlink stuff to it from master.