### PR TITLE
Fix a crashing bug on Linux.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.7+3
+
+* Fix a crashing bug on Linux.
+
 # 0.9.7+2
 
 * Narrow the constraint on `async` to reflect the APIs this package is actually

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 0.9.7+2
+version: 0.9.8-dev
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/watcher
 description: >

--- a/test/directory_watcher/shared.dart
+++ b/test/directory_watcher/shared.dart
@@ -92,6 +92,23 @@ void sharedTests() {
     ]);
   });
 
+  // Regression test for b/30768513.
+  test("doesn't crash when the directory is moved immediately after a subdir "
+      "is added", () {
+    writeFile("dir/a.txt");
+    writeFile("dir/b.txt");
+
+    startWatcher(path: "dir");
+
+    createDir("dir/subdir");
+    renameDir("dir", "moved_dir");
+    createDir("dir");
+    inAnyOrder([
+      isRemoveEvent("dir/a.txt"),
+      isRemoveEvent("dir/b.txt")
+    ]);
+  });
+
   group("moves", () {
     test('notifies when a file is moved within the watched directory', () {
       writeFile("old.txt");


### PR DESCRIPTION
When a directory was removed immediately after a subdirectory was
created, the subdirectory event would be buffered. We'd then attempt
to watch the subdirectory even though the stream group was already
closed.

Fixed b/30768513.