### PR TITLE
Updates for Dart 2.0 corelib changes (wave 2.2).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.9.7+7
+
+* Updates to support Dart 2.0 core library changes (wave 2.2). 
+  See [issue 31847][sdk#31847] for details.
+
+  [sdk#31847]: https://github.com/dart-lang/sdk/issues/31847
+
+
 # 0.9.7+6
 
 * Internal changes only, namely removing dep on scheduled test. 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -78,7 +78,7 @@ Future newFuture(callback()) => new Future.value().then((_) => callback());
 /// asynchronous firing of each event. In order to recreate the synchronous
 /// batches, this collates all the events that are received in "nearby"
 /// microtasks.
-class BatchedStreamTransformer<T> implements StreamTransformer<T, List<T>> {
+class BatchedStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
   Stream<List<T>> bind(Stream<T> input) {
     var batch = new Queue<T>();
     return new StreamTransformer<T, List<T>>.fromHandlers(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: watcher
-version: 0.9.7+6
+version: 0.9.7+7
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/watcher
 description: >
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=2.0.0-dev.20.0 <2.0.0'
 dependencies:
   async: '>=1.10.0 <3.0.0'
   path: '>=0.9.0 <2.0.0'


### PR DESCRIPTION
Make some classes extend `StreamTransformerBase` instead of implement `StreamTransformer`.