### PR TITLE
Add types required in Dart2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Improve support for symlinks. Where possible, symlinks are now treated as
   normal files. For caveats, see the README.
 
+* Fix Dart 2.0 type issues on Mac and Windows.
+
 # 0.9.7+7
 
 * Updates to support Dart 2.0 core library changes (wave 2.2). 

--- a/lib/src/directory_watcher/mac_os.dart
+++ b/lib/src/directory_watcher/mac_os.dart
@@ -171,7 +171,7 @@ class _MacOSDirectoryWatcher
   /// The returned events won't contain any [FileSystemMoveEvent]s, nor will it
   /// contain any events relating to [path].
   Map<String, Set<FileSystemEvent>> _sortEvents(List<FileSystemEvent> batch) {
-    var eventsForPaths = <String, Set>{};
+    var eventsForPaths = <String, Set<FileSystemEvent>>{};
 
     // FSEvents can report past events, including events on the root directory
     // such as it being created. We want to ignore these. If the directory is
@@ -182,20 +182,21 @@ class _MacOSDirectoryWatcher
     // directory's full contents will be examined anyway, so we ignore such
     // events. Emitting them could cause useless or out-of-order events.
     var directories = unionAll(batch.map((event) {
-      if (!event.isDirectory) return new Set();
+      if (!event.isDirectory) return new Set<String>();
       if (event is FileSystemMoveEvent) {
-        return new Set.from([event.path, event.destination]);
+        return new Set<String>.from([event.path, event.destination]);
       }
-      return new Set.from([event.path]);
+      return new Set<String>.from([event.path]);
     }));
 
-    isInModifiedDirectory(path) =>
+    isInModifiedDirectory(String path) =>
         directories.any((dir) => path != dir && path.startsWith(dir));
 
-    addEvent(path, event) {
+    addEvent(String path, FileSystemEvent event) {
       if (isInModifiedDirectory(path)) return;
-      var set = eventsForPaths.putIfAbsent(path, () => new Set());
-      set.add(event);
+      eventsForPaths
+          .putIfAbsent(path, () => new Set<FileSystemEvent>())
+          .add(event);
     }
 
     for (var event in batch) {

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -217,26 +217,27 @@ class _WindowsDirectoryWatcher
   /// The returned events won't contain any [FileSystemMoveEvent]s, nor will it
   /// contain any events relating to [path].
   Map<String, Set<FileSystemEvent>> _sortEvents(List<FileSystemEvent> batch) {
-    var eventsForPaths = <String, Set>{};
+    var eventsForPaths = <String, Set<FileSystemEvent>>{};
 
     // Events within directories that already have events are superfluous; the
     // directory's full contents will be examined anyway, so we ignore such
     // events. Emitting them could cause useless or out-of-order events.
     var directories = unionAll(batch.map((event) {
-      if (!event.isDirectory) return new Set();
+      if (!event.isDirectory) return new Set<String>();
       if (event is FileSystemMoveEvent) {
-        return new Set.from([event.path, event.destination]);
+        return new Set<String>.from([event.path, event.destination]);
       }
-      return new Set.from([event.path]);
+      return new Set<String>.from([event.path]);
     }));
 
-    isInModifiedDirectory(path) =>
+    isInModifiedDirectory(String path) =>
         directories.any((dir) => path != dir && path.startsWith(dir));
 
-    addEvent(path, event) {
+    addEvent(String path, FileSystemEvent event) {
       if (isInModifiedDirectory(path)) return;
-      var set = eventsForPaths.putIfAbsent(path, () => new Set());
-      set.add(event);
+      eventsForPaths
+          .putIfAbsent(path, () => new Set<FileSystemEvent>())
+          .add(event);
     }
 
     for (var event in batch) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -21,8 +21,8 @@ bool isDirectoryNotFoundException(error) {
 }
 
 /// Returns the union of all elements in each set in [sets].
-Set unionAll(Iterable<Set> sets) =>
-    sets.fold(new Set(), (union, set) => union.union(set));
+Set<T> unionAll<T>(Iterable<Set<T>> sets) =>
+    sets.fold(new Set<T>(), (union, set) => union.union(set));
 
 /// Returns a buffered stream that will emit the same values as the stream
 /// returned by [future] once [future] completes.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 0.9.7+7
+version: 0.9.8
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/watcher
 description: >


### PR DESCRIPTION
Context: https://github.com/dart-lang/sdk/issues/32607

With these changes Mac related tests run with `--preview-dart-2` and on Windows `test\directory_watcher\windows_test.dart` runs with errors (because it attempts to delete not empty directories, but not because of Dart2 types failures).