### PR TITLE
Add some stricter analysis

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,14 @@
+analyzer:
+  strong-mode:
+    implicit-casts: false
+  errors:
+    todo: ignore
+    unused_import: error
+    unused_element: error
+    unused_local_variable: error
+    dead_code: error
+
+linter:
+  rules:
+    - comment_references
+    - prefer_typing_uninitialized_variables

--- a/benchmark/path_set.dart
+++ b/benchmark/path_set.dart
@@ -31,7 +31,7 @@ abstract class PathSetBenchmark extends BenchmarkBase {
   /// Each virtual directory contains ten entries: either subdirectories or
   /// files.
   void walkTree(int depth, callback(String path)) {
-    recurse(path, remainingDepth) {
+    recurse(String path, remainingDepth) {
       for (var i = 0; i < 10; i++) {
         var padded = i.toString().padLeft(2, '0');
         if (remainingDepth == 0) {

--- a/lib/src/directory_watcher/linux.dart
+++ b/lib/src/directory_watcher/linux.dart
@@ -79,13 +79,14 @@ class _LinuxDirectoryWatcher
         .transform(new BatchedStreamTransformer<FileSystemEvent>());
     _listen(innerStream, _onBatch, onError: _eventsController.addError);
 
-    _listen(new Directory(path).list(recursive: true), (entity) {
+    _listen(new Directory(path).list(recursive: true),
+        (FileSystemEntity entity) {
       if (entity is Directory) {
         _watchSubdir(entity.path);
       } else {
         _files.add(entity.path);
       }
-    }, onError: (error, stackTrace) {
+    }, onError: (error, StackTrace stackTrace) {
       _eventsController.addError(error, stackTrace);
       close();
     }, onDone: () {
@@ -207,14 +208,15 @@ class _LinuxDirectoryWatcher
 
   /// Emits [ChangeType.ADD] events for the recursive contents of [path].
   void _addSubdir(String path) {
-    _listen(new Directory(path).list(recursive: true), (entity) {
+    _listen(new Directory(path).list(recursive: true),
+        (FileSystemEntity entity) {
       if (entity is Directory) {
         _watchSubdir(entity.path);
       } else {
         _files.add(entity.path);
         _emit(ChangeType.ADD, entity.path);
       }
-    }, onError: (error, stackTrace) {
+    }, onError: (error, StackTrace stackTrace) {
       // Ignore an exception caused by the dir not existing. It's fine if it
       // was added and then quickly removed.
       if (error is FileSystemException) return;
@@ -252,7 +254,7 @@ class _LinuxDirectoryWatcher
   /// [_subscriptions] so that it can be canceled when [close] is called.
   void _listen<T>(Stream<T> stream, void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    var subscription;
+    StreamSubscription subscription;
     subscription = stream.listen(onData, onError: onError, onDone: () {
       _subscriptions.remove(subscription);
       if (onDone != null) onDone();

--- a/lib/src/directory_watcher/mac_os.dart
+++ b/lib/src/directory_watcher/mac_os.dart
@@ -54,8 +54,8 @@ class _MacOSDirectoryWatcher
 
   /// The subscription to the stream returned by [Directory.watch].
   ///
-  /// This is separate from [_subscriptions] because this stream occasionally
-  /// needs to be resubscribed in order to work around issue 14849.
+  /// This is separate from [_listSubscriptions] because this stream
+  /// occasionally needs to be resubscribed in order to work around issue 14849.
   StreamSubscription<List<FileSystemEvent>> _watchSubscription;
 
   /// The subscription to the [Directory.list] call for the initial listing of
@@ -143,7 +143,7 @@ class _MacOSDirectoryWatcher
 
             _emitEvent(ChangeType.ADD, entity.path);
             _files.add(entity.path);
-          }, onError: (e, stackTrace) {
+          }, onError: (e, StackTrace stackTrace) {
             _emitError(e, stackTrace);
           }, onDone: () {
             _listSubscriptions.remove(subscription);
@@ -212,7 +212,7 @@ class _MacOSDirectoryWatcher
   /// one exists.
   ///
   /// If [batch] doesn't contain any contradictory events (e.g. DELETE and
-  /// CREATE, or events with different values for [isDirectory]), this returns a
+  /// CREATE, or events with different values for `isDirectory`), this returns a
   /// single event that describes what happened to the path in question.
   ///
   /// If [batch] does contain contradictory events, this returns `null` to

--- a/lib/src/directory_watcher/polling.dart
+++ b/lib/src/directory_watcher/polling.dart
@@ -19,7 +19,7 @@ class PollingDirectoryWatcher extends ResubscribableWatcher
 
   /// Creates a new polling watcher monitoring [directory].
   ///
-  /// If [_pollingDelay] is passed, it specifies the amount of time the watcher
+  /// If [pollingDelay] is passed, it specifies the amount of time the watcher
   /// will pause between successive polls of the directory contents. Making this
   /// shorter will give more immediate feedback at the expense of doing more IO
   /// and higher CPU usage. Defaults to one second.
@@ -68,13 +68,13 @@ class _PollingDirectoryWatcher
 
   /// The set of files that have been seen in the current directory listing.
   ///
-  /// Used to tell which files have been removed: files that are in [_statuses]
-  /// but not in here when a poll completes have been removed.
+  /// Used to tell which files have been removed: files that are in
+  /// [_lastModifieds] but not in here when a poll completes have been removed.
   final _polledFiles = new Set<String>();
 
   _PollingDirectoryWatcher(this.path, this._pollingDelay) {
-    _filesToProcess =
-        new AsyncQueue<String>(_processFile, onError: (e, stackTrace) {
+    _filesToProcess = new AsyncQueue<String>(_processFile,
+        onError: (e, StackTrace stackTrace) {
       if (!_events.isClosed) _events.addError(e, stackTrace);
     });
 
@@ -113,7 +113,7 @@ class _PollingDirectoryWatcher
 
       if (entity is! File) return;
       _filesToProcess.add(entity.path);
-    }, onError: (error, stackTrace) {
+    }, onError: (error, StackTrace stackTrace) {
       if (!isDirectoryNotFoundException(error)) {
         // It's some unknown error. Pipe it over to the event stream so the
         // user can see it.

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -188,7 +188,7 @@ class _WindowsDirectoryWatcher
             _files.add(entity.path);
           }, onDone: () {
             _listSubscriptions.remove(subscription);
-          }, onError: (e, stackTrace) {
+          }, onError: (e, StackTrace stackTrace) {
             _listSubscriptions.remove(subscription);
             _emitError(e, stackTrace);
           }, cancelOnError: true);
@@ -253,7 +253,7 @@ class _WindowsDirectoryWatcher
   /// one exists.
   ///
   /// If [batch] doesn't contain any contradictory events (e.g. DELETE and
-  /// CREATE, or events with different values for [isDirectory]), this returns a
+  /// CREATE, or events with different values for `isDirectory`), this returns a
   /// single event that describes what happened to the path in question.
   ///
   /// If [batch] does contain contradictory events, this returns `null` to
@@ -382,7 +382,7 @@ class _WindowsDirectoryWatcher
     _files.clear();
     var completer = new Completer();
     var stream = new Directory(path).list(recursive: true);
-    void handleEntity(entity) {
+    void handleEntity(FileSystemEntity entity) {
       if (entity is! Directory) _files.add(entity.path);
     }
 

--- a/lib/src/file_watcher.dart
+++ b/lib/src/file_watcher.dart
@@ -15,7 +15,7 @@ import 'file_watcher/polling.dart';
 /// it will emit a single [ChangeType.REMOVE] event and then close the stream.
 ///
 /// If the file is deleted and quickly replaced (when a new file is moved in its
-/// place, for example) this will emit a [ChangeTime.MODIFY] event.
+/// place, for example) this will emit a [ChangeType.MODIFY] event.
 abstract class FileWatcher implements Watcher {
   /// Creates a new [FileWatcher] monitoring [file].
   ///

--- a/lib/src/file_watcher/polling.dart
+++ b/lib/src/file_watcher/polling.dart
@@ -58,7 +58,7 @@ class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {
       return;
     }
 
-    var modified;
+    DateTime modified;
     try {
       try {
         modified = await getModificationTime(path);

--- a/lib/src/path_set.dart
+++ b/lib/src/path_set.dart
@@ -49,13 +49,13 @@ class PathSet {
   /// empty set.
   Set<String> remove(String path) {
     path = _normalize(path);
-    var parts = new Queue.from(p.split(path));
+    var parts = new Queue.of(p.split(path));
 
     // Remove the children of [dir], as well as [dir] itself if necessary.
     //
     // [partialPath] is the path to [dir], and a prefix of [path]; the remaining
     // components of [path] are in [parts].
-    Set<String> recurse(dir, partialPath) {
+    Set<String> recurse(_Entry dir, String partialPath) {
       if (parts.length > 1) {
         // If there's more than one component left in [path], recurse down to
         // the next level.
@@ -97,7 +97,7 @@ class PathSet {
   /// [dirPath] should be the path to [dir].
   Set<String> _explicitPathsWithin(_Entry dir, String dirPath) {
     var paths = new Set<String>();
-    recurse(dir, path) {
+    recurse(_Entry dir, String path) {
       dir.contents.forEach((name, entry) {
         var entryPath = p.join(path, name);
         if (entry.isExplicit) paths.add(p.join(root, entryPath));
@@ -110,9 +110,9 @@ class PathSet {
     return paths;
   }
 
-  /// Returns whether [this] contains [path].
+  /// Returns whether this set contains [path].
   ///
-  /// This only returns true for paths explicitly added to [this].
+  /// This only returns true for paths explicitly added to this set.
   /// Implicitly-added directories can be inspected using [containsDir].
   bool contains(String path) {
     path = _normalize(path);
@@ -126,7 +126,7 @@ class PathSet {
     return entry.isExplicit;
   }
 
-  /// Returns whether [this] contains paths beneath [path].
+  /// Returns whether this set contains paths beneath [path].
   bool containsDir(String path) {
     path = _normalize(path);
     var entry = _entries;
@@ -143,7 +143,7 @@ class PathSet {
   List<String> get paths {
     var result = <String>[];
 
-    recurse(dir, path) {
+    recurse(_Entry dir, String path) {
       for (var name in dir.contents.keys) {
         var entry = dir.contents[name];
         var entryPath = p.join(path, name);
@@ -156,7 +156,7 @@ class PathSet {
     return result;
   }
 
-  /// Removes all paths from [this].
+  /// Removes all paths from this set.
   void clear() {
     _entries.contents.clear();
   }

--- a/lib/src/resubscribable.dart
+++ b/lib/src/resubscribable.dart
@@ -7,8 +7,6 @@ import 'dart:async';
 import '../watcher.dart';
 import 'watch_event.dart';
 
-typedef ManuallyClosedWatcher WatcherFactory();
-
 /// A wrapper for [ManuallyClosedWatcher] that encapsulates support for closing
 /// the watcher when it has no subscribers and re-opening it when it's
 /// re-subscribed.
@@ -24,7 +22,7 @@ typedef ManuallyClosedWatcher WatcherFactory();
 /// takes a factory function that produces instances of the inner class.
 abstract class ResubscribableWatcher implements Watcher {
   /// The factory function that produces instances of the inner class.
-  final WatcherFactory _factory;
+  final ManuallyClosedWatcher Function() _factory;
 
   final String path;
 
@@ -39,8 +37,8 @@ abstract class ResubscribableWatcher implements Watcher {
   /// Creates a new [ResubscribableWatcher] wrapping the watchers
   /// emitted by [_factory].
   ResubscribableWatcher(this.path, this._factory) {
-    var watcher;
-    var subscription;
+    ManuallyClosedWatcher watcher;
+    StreamSubscription subscription;
 
     _eventsController = new StreamController<WatchEvent>.broadcast(
         onListen: () {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,11 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
-import 'dart:collection';
-
-import 'package:async/async.dart';
 
 /// Returns `true` if [error] is a [FileSystemException] for a missing
 /// directory.
@@ -21,83 +17,3 @@ bool isDirectoryNotFoundException(error) {
 /// Returns the union of all elements in each set in [sets].
 Set<T> unionAll<T>(Iterable<Set<T>> sets) =>
     sets.fold(new Set<T>(), (union, set) => union.union(set));
-
-/// Returns a buffered stream that will emit the same values as the stream
-/// returned by [future] once [future] completes.
-///
-/// If [future] completes to an error, the return value will emit that error and
-/// then close.
-///
-/// If [broadcast] is true, a broadcast stream is returned. This assumes that
-/// the stream returned by [future] will be a broadcast stream as well.
-/// [broadcast] defaults to false.
-Stream<T> futureStream<T>(Future<Stream<T>> future, {bool broadcast: false}) {
-  var subscription;
-  StreamController<T> controller;
-
-  future = DelegatingFuture.typed(future.catchError((e, stackTrace) {
-    // Since [controller] is synchronous, it's likely that emitting an error
-    // will cause it to be cancelled before we call close.
-    if (controller != null) controller.addError(e, stackTrace);
-    if (controller != null) controller.close();
-    controller = null;
-  }));
-
-  onListen() {
-    future.then((stream) {
-      if (controller == null) return;
-      subscription = stream.listen(controller.add,
-          onError: controller.addError, onDone: controller.close);
-    });
-  }
-
-  onCancel() {
-    if (subscription != null) subscription.cancel();
-    subscription = null;
-    controller = null;
-  }
-
-  if (broadcast) {
-    controller = new StreamController.broadcast(
-        sync: true, onListen: onListen, onCancel: onCancel);
-  } else {
-    controller = new StreamController(
-        sync: true, onListen: onListen, onCancel: onCancel);
-  }
-  return controller.stream;
-}
-
-/// Like [new Future], but avoids around issue 11911 by using [new Future.value]
-/// under the covers.
-Future newFuture(callback()) => new Future.value().then((_) => callback());
-
-/// A stream transformer that batches all events that are sent at the same time.
-///
-/// When multiple events are synchronously added to a stream controller, the
-/// [StreamController] implementation uses [scheduleMicrotask] to schedule the
-/// asynchronous firing of each event. In order to recreate the synchronous
-/// batches, this collates all the events that are received in "nearby"
-/// microtasks.
-class BatchedStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
-  Stream<List<T>> bind(Stream<T> input) {
-    var batch = new Queue<T>();
-    return new StreamTransformer<T, List<T>>.fromHandlers(
-        handleData: (event, sink) {
-      batch.add(event);
-
-      // [Timer.run] schedules an event that runs after any microtasks that have
-      // been scheduled.
-      Timer.run(() {
-        if (batch.isEmpty) return;
-        sink.add(batch.toList());
-        batch.clear();
-      });
-    }, handleDone: (sink) {
-      if (batch.isNotEmpty) {
-        sink.add(batch.toList());
-        batch.clear();
-      }
-      sink.close();
-    }).bind(input);
-  }
-}

--- a/test/path_set_test.dart
+++ b/test/path_set_test.dart
@@ -7,83 +7,84 @@ import 'package:test/test.dart';
 import 'package:watcher/src/path_set.dart';
 
 Matcher containsPath(String path) => predicate(
-    (set) => set is PathSet && set.contains(path), 'set contains "$path"');
+    (paths) => paths is PathSet && paths.contains(path),
+    'set contains "$path"');
 
 Matcher containsDir(String path) => predicate(
-    (set) => set is PathSet && set.containsDir(path),
+    (paths) => paths is PathSet && paths.containsDir(path),
     'set contains directory "$path"');
 
 void main() {
-  var set;
-  setUp(() => set = new PathSet("root"));
+  PathSet paths;
+  setUp(() => paths = new PathSet("root"));
 
   group("adding a path", () {
     test("stores the path in the set", () {
-      set.add("root/path/to/file");
-      expect(set, containsPath("root/path/to/file"));
+      paths.add("root/path/to/file");
+      expect(paths, containsPath("root/path/to/file"));
     });
 
     test("that's a subdir of another path keeps both in the set", () {
-      set.add("root/path");
-      set.add("root/path/to/file");
-      expect(set, containsPath("root/path"));
-      expect(set, containsPath("root/path/to/file"));
+      paths.add("root/path");
+      paths.add("root/path/to/file");
+      expect(paths, containsPath("root/path"));
+      expect(paths, containsPath("root/path/to/file"));
     });
 
     test("that's not normalized normalizes the path before storing it", () {
-      set.add("root/../root/path/to/../to/././file");
-      expect(set, containsPath("root/path/to/file"));
+      paths.add("root/../root/path/to/../to/././file");
+      expect(paths, containsPath("root/path/to/file"));
     });
 
     test("that's absolute normalizes the path before storing it", () {
-      set.add(p.absolute("root/path/to/file"));
-      expect(set, containsPath("root/path/to/file"));
+      paths.add(p.absolute("root/path/to/file"));
+      expect(paths, containsPath("root/path/to/file"));
     });
   });
 
   group("removing a path", () {
     test("that's in the set removes and returns that path", () {
-      set.add("root/path/to/file");
-      expect(set.remove("root/path/to/file"),
+      paths.add("root/path/to/file");
+      expect(paths.remove("root/path/to/file"),
           unorderedEquals([p.normalize("root/path/to/file")]));
-      expect(set, isNot(containsPath("root/path/to/file")));
+      expect(paths, isNot(containsPath("root/path/to/file")));
     });
 
     test("that's not in the set returns an empty set", () {
-      set.add("root/path/to/file");
-      expect(set.remove("root/path/to/nothing"), isEmpty);
+      paths.add("root/path/to/file");
+      expect(paths.remove("root/path/to/nothing"), isEmpty);
     });
 
     test("that's a directory removes and returns all files beneath it", () {
-      set.add("root/outside");
-      set.add("root/path/to/one");
-      set.add("root/path/to/two");
-      set.add("root/path/to/sub/three");
+      paths.add("root/outside");
+      paths.add("root/path/to/one");
+      paths.add("root/path/to/two");
+      paths.add("root/path/to/sub/three");
 
       expect(
-          set.remove("root/path"),
+          paths.remove("root/path"),
           unorderedEquals([
             "root/path/to/one",
             "root/path/to/two",
             "root/path/to/sub/three"
           ].map(p.normalize)));
 
-      expect(set, containsPath("root/outside"));
-      expect(set, isNot(containsPath("root/path/to/one")));
-      expect(set, isNot(containsPath("root/path/to/two")));
-      expect(set, isNot(containsPath("root/path/to/sub/three")));
+      expect(paths, containsPath("root/outside"));
+      expect(paths, isNot(containsPath("root/path/to/one")));
+      expect(paths, isNot(containsPath("root/path/to/two")));
+      expect(paths, isNot(containsPath("root/path/to/sub/three")));
     });
 
     test(
         "that's a directory in the set removes and returns it and all files "
         "beneath it", () {
-      set.add("root/path");
-      set.add("root/path/to/one");
-      set.add("root/path/to/two");
-      set.add("root/path/to/sub/three");
+      paths.add("root/path");
+      paths.add("root/path/to/one");
+      paths.add("root/path/to/two");
+      paths.add("root/path/to/sub/three");
 
       expect(
-          set.remove("root/path"),
+          paths.remove("root/path"),
           unorderedEquals([
             "root/path",
             "root/path/to/one",
@@ -91,113 +92,113 @@ void main() {
             "root/path/to/sub/three"
           ].map(p.normalize)));
 
-      expect(set, isNot(containsPath("root/path")));
-      expect(set, isNot(containsPath("root/path/to/one")));
-      expect(set, isNot(containsPath("root/path/to/two")));
-      expect(set, isNot(containsPath("root/path/to/sub/three")));
+      expect(paths, isNot(containsPath("root/path")));
+      expect(paths, isNot(containsPath("root/path/to/one")));
+      expect(paths, isNot(containsPath("root/path/to/two")));
+      expect(paths, isNot(containsPath("root/path/to/sub/three")));
     });
 
     test("that's not normalized removes and returns the normalized path", () {
-      set.add("root/path/to/file");
-      expect(set.remove("root/../root/path/to/../to/./file"),
+      paths.add("root/path/to/file");
+      expect(paths.remove("root/../root/path/to/../to/./file"),
           unorderedEquals([p.normalize("root/path/to/file")]));
     });
 
     test("that's absolute removes and returns the normalized path", () {
-      set.add("root/path/to/file");
-      expect(set.remove(p.absolute("root/path/to/file")),
+      paths.add("root/path/to/file");
+      expect(paths.remove(p.absolute("root/path/to/file")),
           unorderedEquals([p.normalize("root/path/to/file")]));
     });
   });
 
   group("containsPath()", () {
     test("returns false for a non-existent path", () {
-      set.add("root/path/to/file");
-      expect(set, isNot(containsPath("root/path/to/nothing")));
+      paths.add("root/path/to/file");
+      expect(paths, isNot(containsPath("root/path/to/nothing")));
     });
 
     test("returns false for a directory that wasn't added explicitly", () {
-      set.add("root/path/to/file");
-      expect(set, isNot(containsPath("root/path")));
+      paths.add("root/path/to/file");
+      expect(paths, isNot(containsPath("root/path")));
     });
 
     test("returns true for a directory that was added explicitly", () {
-      set.add("root/path");
-      set.add("root/path/to/file");
-      expect(set, containsPath("root/path"));
+      paths.add("root/path");
+      paths.add("root/path/to/file");
+      expect(paths, containsPath("root/path"));
     });
 
     test("with a non-normalized path normalizes the path before looking it up",
         () {
-      set.add("root/path/to/file");
-      expect(set, containsPath("root/../root/path/to/../to/././file"));
+      paths.add("root/path/to/file");
+      expect(paths, containsPath("root/../root/path/to/../to/././file"));
     });
 
     test("with an absolute path normalizes the path before looking it up", () {
-      set.add("root/path/to/file");
-      expect(set, containsPath(p.absolute("root/path/to/file")));
+      paths.add("root/path/to/file");
+      expect(paths, containsPath(p.absolute("root/path/to/file")));
     });
   });
 
   group("containsDir()", () {
     test("returns true for a directory that was added implicitly", () {
-      set.add("root/path/to/file");
-      expect(set, containsDir("root/path"));
-      expect(set, containsDir("root/path/to"));
+      paths.add("root/path/to/file");
+      expect(paths, containsDir("root/path"));
+      expect(paths, containsDir("root/path/to"));
     });
 
     test("returns true for a directory that was added explicitly", () {
-      set.add("root/path");
-      set.add("root/path/to/file");
-      expect(set, containsDir("root/path"));
+      paths.add("root/path");
+      paths.add("root/path/to/file");
+      expect(paths, containsDir("root/path"));
     });
 
     test("returns false for a directory that wasn't added", () {
-      expect(set, isNot(containsDir("root/nothing")));
+      expect(paths, isNot(containsDir("root/nothing")));
     });
 
     test("returns false for a non-directory path that was added", () {
-      set.add("root/path/to/file");
-      expect(set, isNot(containsDir("root/path/to/file")));
+      paths.add("root/path/to/file");
+      expect(paths, isNot(containsDir("root/path/to/file")));
     });
 
     test(
         "returns false for a directory that was added implicitly and then "
         "removed implicitly", () {
-      set.add("root/path/to/file");
-      set.remove("root/path/to/file");
-      expect(set, isNot(containsDir("root/path")));
+      paths.add("root/path/to/file");
+      paths.remove("root/path/to/file");
+      expect(paths, isNot(containsDir("root/path")));
     });
 
     test(
         "returns false for a directory that was added explicitly whose "
         "children were then removed", () {
-      set.add("root/path");
-      set.add("root/path/to/file");
-      set.remove("root/path/to/file");
-      expect(set, isNot(containsDir("root/path")));
+      paths.add("root/path");
+      paths.add("root/path/to/file");
+      paths.remove("root/path/to/file");
+      expect(paths, isNot(containsDir("root/path")));
     });
 
     test("with a non-normalized path normalizes the path before looking it up",
         () {
-      set.add("root/path/to/file");
-      expect(set, containsDir("root/../root/path/to/../to/."));
+      paths.add("root/path/to/file");
+      expect(paths, containsDir("root/../root/path/to/../to/."));
     });
 
     test("with an absolute path normalizes the path before looking it up", () {
-      set.add("root/path/to/file");
-      expect(set, containsDir(p.absolute("root/path")));
+      paths.add("root/path/to/file");
+      expect(paths, containsDir(p.absolute("root/path")));
     });
   });
 
   group("paths", () {
     test("returns paths added to the set", () {
-      set.add("root/path");
-      set.add("root/path/to/one");
-      set.add("root/path/to/two");
+      paths.add("root/path");
+      paths.add("root/path/to/one");
+      paths.add("root/path/to/two");
 
       expect(
-          set.paths,
+          paths.paths,
           unorderedEquals([
             "root/path",
             "root/path/to/one",
@@ -206,22 +207,22 @@ void main() {
     });
 
     test("doesn't return paths removed from the set", () {
-      set.add("root/path/to/one");
-      set.add("root/path/to/two");
-      set.remove("root/path/to/two");
+      paths.add("root/path/to/one");
+      paths.add("root/path/to/two");
+      paths.remove("root/path/to/two");
 
-      expect(set.paths, unorderedEquals([p.normalize("root/path/to/one")]));
+      expect(paths.paths, unorderedEquals([p.normalize("root/path/to/one")]));
     });
   });
 
   group("clear", () {
     test("removes all paths from the set", () {
-      set.add("root/path");
-      set.add("root/path/to/one");
-      set.add("root/path/to/two");
+      paths.add("root/path");
+      paths.add("root/path/to/one");
+      paths.add("root/path/to/two");
 
-      set.clear();
-      expect(set.paths, isEmpty);
+      paths.clear();
+      expect(paths.paths, isEmpty);
     });
   });
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -35,10 +35,6 @@ WatcherFactory _watcherFactory;
 
 /// Creates a new [Watcher] that watches a temporary file or directory.
 ///
-/// Normally, this will pause the schedule until the watcher is done scanning
-/// and is polling for changes. If you pass `false` for [waitForReady], it will
-/// not schedule this delay.
-///
 /// If [path] is provided, watches a subdirectory in the sandbox with that name.
 Watcher createWatcher({String path}) {
   if (path == null) {
@@ -202,7 +198,7 @@ Future allowRemoveEvent(String path) =>
 
 /// Schedules writing a file in the sandbox at [path] with [contents].
 ///
-/// If [contents] is omitted, creates an empty file. If [updatedModified] is
+/// If [contents] is omitted, creates an empty file. If [updateModified] is
 /// `false`, the mock file modification time is not changed.
 void writeFile(String path, {String contents, bool updateModified}) {
   if (contents == null) contents = "";
@@ -232,8 +228,6 @@ void deleteFile(String path) {
 }
 
 /// Schedules renaming a file in the sandbox from [from] to [to].
-///
-/// If [contents] is omitted, creates an empty file.
 void renameFile(String from, String to) {
   new File(p.join(d.sandbox, from)).renameSync(p.join(d.sandbox, to));
 
@@ -259,8 +253,8 @@ void deleteDir(String path) {
   new Directory(p.join(d.sandbox, path)).deleteSync(recursive: true);
 }
 
-/// Runs [callback] with every permutation of non-negative [i], [j], and [k]
-/// less than [limit].
+/// Runs [callback] with every permutation of non-negative numbers for each
+/// argument less than [limit].
 ///
 /// Returns a set of all values returns by [callback].
 ///


### PR DESCRIPTION
- Enable errors that would fail internally
- Add `comment_references` lint - this makes DartDocs output more usable
  and there isn't any reason to have unclickable references.
- Add `prefer_typing_uninitialized_variables` lint - this prevents some
  unintentionally dynamic behavior.
- Disable implicit casts.
- Use function type syntax for the ManuallyClosedWatcher factory.
- Remove some unused utilities.