### PR TITLE
Run dartfmt --fix

### DIFF
--- a/benchmark/path_set.dart
+++ b/benchmark/path_set.dart
@@ -19,11 +19,11 @@ final String root = Platform.isWindows ? r"C:\root" : "/root";
 abstract class PathSetBenchmark extends BenchmarkBase {
   PathSetBenchmark(String method) : super("PathSet.$method");
 
-  final PathSet pathSet = new PathSet(root);
+  final PathSet pathSet = PathSet(root);
 
   /// Use a fixed [Random] with a constant seed to ensure the tests are
   /// deterministic.
-  final math.Random random = new math.Random(1234);
+  final math.Random random = math.Random(1234);
 
   /// Walks over a virtual directory [depth] levels deep invoking [callback]
   /// for each "file".
@@ -140,8 +140,8 @@ class RemoveBenchmark extends PathSetBenchmark {
 }
 
 main() {
-  new AddBenchmark().report();
-  new ContainsBenchmark().report();
-  new PathsBenchmark().report();
-  new RemoveBenchmark().report();
+  AddBenchmark().report();
+  ContainsBenchmark().report();
+  PathsBenchmark().report();
+  RemoveBenchmark().report();
 }

--- a/example/watch.dart
+++ b/example/watch.dart
@@ -14,7 +14,7 @@ main(List<String> arguments) {
     return;
   }
 
-  var watcher = new DirectoryWatcher(p.absolute(arguments[0]));
+  var watcher = DirectoryWatcher(p.absolute(arguments[0]));
   watcher.events.listen((event) {
     print(event);
   });

--- a/lib/src/async_queue.dart
+++ b/lib/src/async_queue.dart
@@ -17,7 +17,7 @@ typedef Future ItemProcessor<T>(T item);
 /// needed. When all items are processed, it stops processing until more items
 /// are added.
 class AsyncQueue<T> {
-  final _items = new Queue<T>();
+  final _items = Queue<T>();
 
   /// Whether or not the queue is currently waiting on a processing future to
   /// complete.

--- a/lib/src/directory_watcher.dart
+++ b/lib/src/directory_watcher.dart
@@ -29,10 +29,10 @@ abstract class DirectoryWatcher implements Watcher {
   /// watchers.
   factory DirectoryWatcher(String directory, {Duration pollingDelay}) {
     if (FileSystemEntity.isWatchSupported) {
-      if (Platform.isLinux) return new LinuxDirectoryWatcher(directory);
-      if (Platform.isMacOS) return new MacOSDirectoryWatcher(directory);
-      if (Platform.isWindows) return new WindowsDirectoryWatcher(directory);
+      if (Platform.isLinux) return LinuxDirectoryWatcher(directory);
+      if (Platform.isMacOS) return MacOSDirectoryWatcher(directory);
+      if (Platform.isWindows) return WindowsDirectoryWatcher(directory);
     }
-    return new PollingDirectoryWatcher(directory, pollingDelay: pollingDelay);
+    return PollingDirectoryWatcher(directory, pollingDelay: pollingDelay);
   }
 }

--- a/lib/src/directory_watcher/polling.dart
+++ b/lib/src/directory_watcher/polling.dart
@@ -25,8 +25,8 @@ class PollingDirectoryWatcher extends ResubscribableWatcher
   /// and higher CPU usage. Defaults to one second.
   PollingDirectoryWatcher(String directory, {Duration pollingDelay})
       : super(directory, () {
-          return new _PollingDirectoryWatcher(directory,
-              pollingDelay != null ? pollingDelay : new Duration(seconds: 1));
+          return _PollingDirectoryWatcher(directory,
+              pollingDelay != null ? pollingDelay : Duration(seconds: 1));
         });
 }
 
@@ -36,12 +36,12 @@ class _PollingDirectoryWatcher
   final String path;
 
   Stream<WatchEvent> get events => _events.stream;
-  final _events = new StreamController<WatchEvent>.broadcast();
+  final _events = StreamController<WatchEvent>.broadcast();
 
   bool get isReady => _ready.isCompleted;
 
   Future get ready => _ready.future;
-  final _ready = new Completer();
+  final _ready = Completer();
 
   /// The amount of time the watcher pauses between successive polls of the
   /// directory contents.
@@ -50,7 +50,7 @@ class _PollingDirectoryWatcher
   /// The previous modification times of the files in the directory.
   ///
   /// Used to tell which files have been modified.
-  final _lastModifieds = new Map<String, DateTime>();
+  final _lastModifieds = Map<String, DateTime>();
 
   /// The subscription used while [directory] is being listed.
   ///
@@ -70,11 +70,11 @@ class _PollingDirectoryWatcher
   ///
   /// Used to tell which files have been removed: files that are in
   /// [_lastModifieds] but not in here when a poll completes have been removed.
-  final _polledFiles = new Set<String>();
+  final _polledFiles = Set<String>();
 
   _PollingDirectoryWatcher(this.path, this._pollingDelay) {
-    _filesToProcess = new AsyncQueue<String>(_processFile,
-        onError: (e, StackTrace stackTrace) {
+    _filesToProcess =
+        AsyncQueue<String>(_processFile, onError: (e, StackTrace stackTrace) {
       if (!_events.isClosed) _events.addError(e, stackTrace);
     });
 
@@ -107,7 +107,7 @@ class _PollingDirectoryWatcher
       _filesToProcess.add(null);
     }
 
-    var stream = new Directory(path).list(recursive: true);
+    var stream = Directory(path).list(recursive: true);
     _listSubscription = stream.listen((entity) {
       assert(!_events.isClosed);
 
@@ -154,7 +154,7 @@ class _PollingDirectoryWatcher
       if (!isReady) return null;
 
       var type = lastModified == null ? ChangeType.ADD : ChangeType.MODIFY;
-      _events.add(new WatchEvent(type, file));
+      _events.add(WatchEvent(type, file));
     });
   }
 
@@ -165,14 +165,14 @@ class _PollingDirectoryWatcher
     // status for must have been removed.
     var removedFiles = _lastModifieds.keys.toSet().difference(_polledFiles);
     for (var removed in removedFiles) {
-      if (isReady) _events.add(new WatchEvent(ChangeType.REMOVE, removed));
+      if (isReady) _events.add(WatchEvent(ChangeType.REMOVE, removed));
       _lastModifieds.remove(removed);
     }
 
     if (!isReady) _ready.complete();
 
     // Wait and then poll again.
-    return new Future.delayed(_pollingDelay).then((_) {
+    return Future.delayed(_pollingDelay).then((_) {
       if (_events.isClosed) return;
       _poll();
     });

--- a/lib/src/file_watcher.dart
+++ b/lib/src/file_watcher.dart
@@ -33,8 +33,8 @@ abstract class FileWatcher implements Watcher {
     // [FileSystemEntity.isWatchSupported] is still true because directory
     // watching does work.
     if (FileSystemEntity.isWatchSupported && !Platform.isWindows) {
-      return new NativeFileWatcher(file);
+      return NativeFileWatcher(file);
     }
-    return new PollingFileWatcher(file, pollingDelay: pollingDelay);
+    return PollingFileWatcher(file, pollingDelay: pollingDelay);
   }
 }

--- a/lib/src/file_watcher/native.dart
+++ b/lib/src/file_watcher/native.dart
@@ -15,20 +15,19 @@ import '../watch_event.dart';
 /// Single-file notifications are much simpler than those for multiple files, so
 /// this doesn't need to be split out into multiple OS-specific classes.
 class NativeFileWatcher extends ResubscribableWatcher implements FileWatcher {
-  NativeFileWatcher(String path)
-      : super(path, () => new _NativeFileWatcher(path));
+  NativeFileWatcher(String path) : super(path, () => _NativeFileWatcher(path));
 }
 
 class _NativeFileWatcher implements FileWatcher, ManuallyClosedWatcher {
   final String path;
 
   Stream<WatchEvent> get events => _eventsController.stream;
-  final _eventsController = new StreamController<WatchEvent>.broadcast();
+  final _eventsController = StreamController<WatchEvent>.broadcast();
 
   bool get isReady => _readyCompleter.isCompleted;
 
   Future get ready => _readyCompleter.future;
-  final _readyCompleter = new Completer();
+  final _readyCompleter = Completer();
 
   StreamSubscription _subscription;
 
@@ -42,9 +41,9 @@ class _NativeFileWatcher implements FileWatcher, ManuallyClosedWatcher {
 
   void _listen() {
     // Batch the events together so that we can dedup them.
-    _subscription = new File(path)
+    _subscription = File(path)
         .watch()
-        .transform(new BatchedStreamTransformer<FileSystemEvent>())
+        .transform(BatchedStreamTransformer<FileSystemEvent>())
         .listen(_onBatch, onError: _eventsController.addError, onDone: _onDone);
   }
 
@@ -55,11 +54,11 @@ class _NativeFileWatcher implements FileWatcher, ManuallyClosedWatcher {
       return;
     }
 
-    _eventsController.add(new WatchEvent(ChangeType.MODIFY, path));
+    _eventsController.add(WatchEvent(ChangeType.MODIFY, path));
   }
 
   _onDone() async {
-    var fileExists = await new File(path).exists();
+    var fileExists = await File(path).exists();
 
     // Check for this after checking whether the file exists because it's
     // possible that [close] was called between [File.exists] being called and
@@ -70,10 +69,10 @@ class _NativeFileWatcher implements FileWatcher, ManuallyClosedWatcher {
       // If the file exists now, it was probably removed and quickly replaced;
       // this can happen for example when another file is moved on top of it.
       // Re-subscribe and report a modify event.
-      _eventsController.add(new WatchEvent(ChangeType.MODIFY, path));
+      _eventsController.add(WatchEvent(ChangeType.MODIFY, path));
       _listen();
     } else {
-      _eventsController.add(new WatchEvent(ChangeType.REMOVE, path));
+      _eventsController.add(WatchEvent(ChangeType.REMOVE, path));
       close();
     }
   }

--- a/lib/src/file_watcher/polling.dart
+++ b/lib/src/file_watcher/polling.dart
@@ -14,8 +14,8 @@ import '../watch_event.dart';
 class PollingFileWatcher extends ResubscribableWatcher implements FileWatcher {
   PollingFileWatcher(String path, {Duration pollingDelay})
       : super(path, () {
-          return new _PollingFileWatcher(path,
-              pollingDelay != null ? pollingDelay : new Duration(seconds: 1));
+          return _PollingFileWatcher(
+              path, pollingDelay != null ? pollingDelay : Duration(seconds: 1));
         });
 }
 
@@ -23,12 +23,12 @@ class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {
   final String path;
 
   Stream<WatchEvent> get events => _eventsController.stream;
-  final _eventsController = new StreamController<WatchEvent>.broadcast();
+  final _eventsController = StreamController<WatchEvent>.broadcast();
 
   bool get isReady => _readyCompleter.isCompleted;
 
   Future get ready => _readyCompleter.future;
-  final _readyCompleter = new Completer();
+  final _readyCompleter = Completer();
 
   /// The timer that controls polling.
   Timer _timer;
@@ -40,7 +40,7 @@ class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {
   DateTime _lastModified;
 
   _PollingFileWatcher(this.path, Duration pollingDelay) {
-    _timer = new Timer.periodic(pollingDelay, (_) => _poll());
+    _timer = Timer.periodic(pollingDelay, (_) => _poll());
     _poll();
   }
 
@@ -49,11 +49,11 @@ class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {
     // We don't mark the file as removed if this is the first poll (indicated by
     // [_lastModified] being null). Instead, below we forward the dart:io error
     // that comes from trying to read the mtime below.
-    var pathExists = await new File(path).exists();
+    var pathExists = await File(path).exists();
     if (_eventsController.isClosed) return;
 
     if (_lastModified != null && !pathExists) {
-      _eventsController.add(new WatchEvent(ChangeType.REMOVE, path));
+      _eventsController.add(WatchEvent(ChangeType.REMOVE, path));
       close();
       return;
     }
@@ -80,7 +80,7 @@ class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {
       _readyCompleter.complete();
     } else {
       _lastModified = modified;
-      _eventsController.add(new WatchEvent(ChangeType.MODIFY, path));
+      _eventsController.add(WatchEvent(ChangeType.MODIFY, path));
     }
   }
 

--- a/lib/src/path_set.dart
+++ b/lib/src/path_set.dart
@@ -22,7 +22,7 @@ class PathSet {
   /// Each entry represents a directory or file. It may be a file or directory
   /// that was explicitly added, or a parent directory that was implicitly
   /// added in order to add a child.
-  final _Entry _entries = new _Entry();
+  final _Entry _entries = _Entry();
 
   PathSet(this.root);
 
@@ -33,7 +33,7 @@ class PathSet {
     var parts = p.split(path);
     var entry = _entries;
     for (var part in parts) {
-      entry = entry.contents.putIfAbsent(part, () => new _Entry());
+      entry = entry.contents.putIfAbsent(part, () => _Entry());
     }
 
     entry.isExplicit = true;
@@ -49,7 +49,7 @@ class PathSet {
   /// empty set.
   Set<String> remove(String path) {
     path = _normalize(path);
-    var parts = new Queue.of(p.split(path));
+    var parts = Queue.of(p.split(path));
 
     // Remove the children of [dir], as well as [dir] itself if necessary.
     //
@@ -61,7 +61,7 @@ class PathSet {
         // the next level.
         var part = parts.removeFirst();
         var entry = dir.contents[part];
-        if (entry == null || entry.contents.isEmpty) return new Set();
+        if (entry == null || entry.contents.isEmpty) return Set();
 
         partialPath = p.join(partialPath, part);
         var paths = recurse(entry, partialPath);
@@ -75,10 +75,10 @@ class PathSet {
 
       // If there's only one component left in [path], we should remove it.
       var entry = dir.contents.remove(parts.first);
-      if (entry == null) return new Set();
+      if (entry == null) return Set();
 
       if (entry.contents.isEmpty) {
-        return new Set.from([p.join(root, path)]);
+        return Set.from([p.join(root, path)]);
       }
 
       var set = _explicitPathsWithin(entry, path);
@@ -96,7 +96,7 @@ class PathSet {
   ///
   /// [dirPath] should be the path to [dir].
   Set<String> _explicitPathsWithin(_Entry dir, String dirPath) {
-    var paths = new Set<String>();
+    var paths = Set<String>();
     recurse(_Entry dir, String path) {
       dir.contents.forEach((name, entry) {
         var entryPath = p.join(path, name);

--- a/lib/src/resubscribable.dart
+++ b/lib/src/resubscribable.dart
@@ -32,7 +32,7 @@ abstract class ResubscribableWatcher implements Watcher {
   bool get isReady => _readyCompleter.isCompleted;
 
   Future get ready => _readyCompleter.future;
-  var _readyCompleter = new Completer();
+  var _readyCompleter = Completer();
 
   /// Creates a new [ResubscribableWatcher] wrapping the watchers
   /// emitted by [_factory].
@@ -40,7 +40,7 @@ abstract class ResubscribableWatcher implements Watcher {
     ManuallyClosedWatcher watcher;
     StreamSubscription subscription;
 
-    _eventsController = new StreamController<WatchEvent>.broadcast(
+    _eventsController = StreamController<WatchEvent>.broadcast(
         onListen: () {
           watcher = _factory();
           subscription = watcher.events.listen(_eventsController.add,
@@ -57,7 +57,7 @@ abstract class ResubscribableWatcher implements Watcher {
           // watcher's `onDone` event doesn't close [events].
           subscription.cancel();
           watcher.close();
-          _readyCompleter = new Completer();
+          _readyCompleter = Completer();
         },
         sync: true);
   }

--- a/lib/src/stat.dart
+++ b/lib/src/stat.dart
@@ -24,7 +24,7 @@ void mockGetModificationTime(MockTimeCallback callback) {
 /// Gets the modification time for the file at [path].
 Future<DateTime> getModificationTime(String path) {
   if (_mockTimeCallback != null) {
-    return new Future.value(_mockTimeCallback(path));
+    return Future.value(_mockTimeCallback(path));
   }
 
   return FileStat.stat(path).then((stat) => stat.modified);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -18,7 +18,7 @@ bool isDirectoryNotFoundException(error) {
 
 /// Returns the union of all elements in each set in [sets].
 Set<T> unionAll<T>(Iterable<Set<T>> sets) =>
-    sets.fold(new Set<T>(), (union, set) => union.union(set));
+    sets.fold(Set<T>(), (union, set) => union.union(set));
 
 /// A stream transformer that batches all events that are sent at the same time.
 ///
@@ -29,8 +29,8 @@ Set<T> unionAll<T>(Iterable<Set<T>> sets) =>
 /// microtasks.
 class BatchedStreamTransformer<T> extends StreamTransformerBase<T, List<T>> {
   Stream<List<T>> bind(Stream<T> input) {
-    var batch = new Queue<T>();
-    return new StreamTransformer<T, List<T>>.fromHandlers(
+    var batch = Queue<T>();
+    return StreamTransformer<T, List<T>>.fromHandlers(
         handleData: (event, sink) {
       batch.add(event);
 

--- a/lib/src/watch_event.dart
+++ b/lib/src/watch_event.dart
@@ -18,13 +18,13 @@ class WatchEvent {
 /// Enum for what kind of change has happened to a file.
 class ChangeType {
   /// A new file has been added.
-  static const ADD = const ChangeType("add");
+  static const ADD = ChangeType("add");
 
   /// A file has been removed.
-  static const REMOVE = const ChangeType("remove");
+  static const REMOVE = ChangeType("remove");
 
   /// The contents of a file have changed.
-  static const MODIFY = const ChangeType("modify");
+  static const MODIFY = ChangeType("modify");
 
   final String _name;
   const ChangeType(this._name);

--- a/lib/watcher.dart
+++ b/lib/watcher.dart
@@ -58,10 +58,10 @@ abstract class Watcher {
   /// and higher CPU usage. Defaults to one second. Ignored for non-polling
   /// watchers.
   factory Watcher(String path, {Duration pollingDelay}) {
-    if (new File(path).existsSync()) {
-      return new FileWatcher(path, pollingDelay: pollingDelay);
+    if (File(path).existsSync()) {
+      return FileWatcher(path, pollingDelay: pollingDelay);
     } else {
-      return new DirectoryWatcher(path, pollingDelay: pollingDelay);
+      return DirectoryWatcher(path, pollingDelay: pollingDelay);
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/watcher
 
 environment:
-  sdk: '>=2.0.0-dev.61.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   async: '>=1.10.0 <3.0.0'

--- a/test/directory_watcher/linux_test.dart
+++ b/test/directory_watcher/linux_test.dart
@@ -12,12 +12,12 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new LinuxDirectoryWatcher(dir);
+  watcherFactory = (dir) => LinuxDirectoryWatcher(dir);
 
   sharedTests();
 
   test('DirectoryWatcher creates a LinuxDirectoryWatcher on Linux', () {
-    expect(new DirectoryWatcher('.'), new TypeMatcher<LinuxDirectoryWatcher>());
+    expect(DirectoryWatcher('.'), TypeMatcher<LinuxDirectoryWatcher>());
   });
 
   test('emits events for many nested files moved out then immediately back in',

--- a/test/directory_watcher/mac_os_test.dart
+++ b/test/directory_watcher/mac_os_test.dart
@@ -12,12 +12,12 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new MacOSDirectoryWatcher(dir);
+  watcherFactory = (dir) => MacOSDirectoryWatcher(dir);
 
   sharedTests();
 
   test('DirectoryWatcher creates a MacOSDirectoryWatcher on Mac OS', () {
-    expect(new DirectoryWatcher('.'), new TypeMatcher<MacOSDirectoryWatcher>());
+    expect(DirectoryWatcher('.'), TypeMatcher<MacOSDirectoryWatcher>());
   });
 
   test(

--- a/test/directory_watcher/polling_test.dart
+++ b/test/directory_watcher/polling_test.dart
@@ -10,8 +10,8 @@ import '../utils.dart';
 
 void main() {
   // Use a short delay to make the tests run quickly.
-  watcherFactory = (dir) => new PollingDirectoryWatcher(dir,
-      pollingDelay: new Duration(milliseconds: 100));
+  watcherFactory = (dir) =>
+      PollingDirectoryWatcher(dir, pollingDelay: Duration(milliseconds: 100));
 
   sharedTests();
 

--- a/test/directory_watcher/shared.dart
+++ b/test/directory_watcher/shared.dart
@@ -276,7 +276,7 @@ void sharedTests() {
         isAddEvent("new")
       ]);
     }, onPlatform: {
-      "mac-os": new Skip("https://github.com/dart-lang/watcher/issues/21")
+      "mac-os": Skip("https://github.com/dart-lang/watcher/issues/21")
     });
 
     test('emits events for many nested files added at once', () async {
@@ -316,7 +316,7 @@ void sharedTests() {
       renameDir("dir/old", "dir/new");
 
       await inAnyOrder(unionAll(withPermutations((i, j, k) {
-        return new Set.from([
+        return Set.from([
           isRemoveEvent("dir/old/sub-$i/sub-$j/file-$k.txt"),
           isAddEvent("dir/new/sub-$i/sub-$j/file-$k.txt")
         ]);

--- a/test/directory_watcher/windows_test.dart
+++ b/test/directory_watcher/windows_test.dart
@@ -12,7 +12,7 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new WindowsDirectoryWatcher(dir);
+  watcherFactory = (dir) => WindowsDirectoryWatcher(dir);
 
   // TODO(grouma) - renable when https://github.com/dart-lang/sdk/issues/31760
   // is resolved.
@@ -21,7 +21,6 @@ void main() {
   }, skip: "SDK issue see - https://github.com/dart-lang/sdk/issues/31760");
 
   test('DirectoryWatcher creates a WindowsDirectoryWatcher on Windows', () {
-    expect(
-        new DirectoryWatcher('.'), new TypeMatcher<WindowsDirectoryWatcher>());
+    expect(DirectoryWatcher('.'), TypeMatcher<WindowsDirectoryWatcher>());
   });
 }

--- a/test/file_watcher/native_test.dart
+++ b/test/file_watcher/native_test.dart
@@ -11,7 +11,7 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (file) => new NativeFileWatcher(file);
+  watcherFactory = (file) => NativeFileWatcher(file);
 
   setUp(() {
     writeFile("file.txt");

--- a/test/file_watcher/polling_test.dart
+++ b/test/file_watcher/polling_test.dart
@@ -11,8 +11,8 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (file) => new PollingFileWatcher(file,
-      pollingDelay: new Duration(milliseconds: 100));
+  watcherFactory = (file) =>
+      PollingFileWatcher(file, pollingDelay: Duration(milliseconds: 100));
 
   setUp(() {
     writeFile("file.txt");

--- a/test/file_watcher/shared.dart
+++ b/test/file_watcher/shared.dart
@@ -64,7 +64,7 @@ void sharedTests() {
     var sub = watcher.events.listen(null);
 
     deleteFile("file.txt");
-    await new Future.delayed(new Duration(milliseconds: 10));
+    await Future.delayed(Duration(milliseconds: 10));
     await sub.cancel();
   });
 }

--- a/test/no_subscription/linux_test.dart
+++ b/test/no_subscription/linux_test.dart
@@ -11,7 +11,7 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new LinuxDirectoryWatcher(dir);
+  watcherFactory = (dir) => LinuxDirectoryWatcher(dir);
 
   sharedTests();
 }

--- a/test/no_subscription/mac_os_test.dart
+++ b/test/no_subscription/mac_os_test.dart
@@ -12,7 +12,7 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new MacOSDirectoryWatcher(dir);
+  watcherFactory = (dir) => MacOSDirectoryWatcher(dir);
 
   sharedTests();
 }

--- a/test/no_subscription/polling_test.dart
+++ b/test/no_subscription/polling_test.dart
@@ -8,7 +8,7 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new PollingDirectoryWatcher(dir);
+  watcherFactory = (dir) => PollingDirectoryWatcher(dir);
 
   sharedTests();
 }

--- a/test/no_subscription/shared.dart
+++ b/test/no_subscription/shared.dart
@@ -14,7 +14,7 @@ void sharedTests() {
     // utils.dart because it needs to be very explicit about when the event
     // stream is and is not subscribed.
     var watcher = createWatcher();
-    var queue = new StreamQueue(watcher.events);
+    var queue = StreamQueue(watcher.events);
     queue.hasNext;
 
     var future =
@@ -33,7 +33,7 @@ void sharedTests() {
     // Now write a file while we aren't listening.
     writeFile("unwatched.txt");
 
-    queue = new StreamQueue(watcher.events);
+    queue = StreamQueue(watcher.events);
     future =
         expectLater(queue, emits(isWatchEvent(ChangeType.ADD, "added.txt")));
     expect(queue, neverEmits(isWatchEvent(ChangeType.ADD, "unwatched.txt")));

--- a/test/path_set_test.dart
+++ b/test/path_set_test.dart
@@ -16,7 +16,7 @@ Matcher containsDir(String path) => predicate(
 
 void main() {
   PathSet paths;
-  setUp(() => paths = new PathSet("root"));
+  setUp(() => paths = PathSet("root"));
 
   group("adding a path", () {
     test("stores the path in the set", () {

--- a/test/ready/linux_test.dart
+++ b/test/ready/linux_test.dart
@@ -11,7 +11,7 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new LinuxDirectoryWatcher(dir);
+  watcherFactory = (dir) => LinuxDirectoryWatcher(dir);
 
   sharedTests();
 }

--- a/test/ready/mac_os_test.dart
+++ b/test/ready/mac_os_test.dart
@@ -11,7 +11,7 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new MacOSDirectoryWatcher(dir);
+  watcherFactory = (dir) => MacOSDirectoryWatcher(dir);
 
   sharedTests();
 }

--- a/test/ready/polling_test.dart
+++ b/test/ready/polling_test.dart
@@ -8,7 +8,7 @@ import 'shared.dart';
 import '../utils.dart';
 
 void main() {
-  watcherFactory = (dir) => new PollingDirectoryWatcher(dir);
+  watcherFactory = (dir) => PollingDirectoryWatcher(dir);
 
   sharedTests();
 }

--- a/test/ready/shared.dart
+++ b/test/ready/shared.dart
@@ -38,7 +38,7 @@ void sharedTests() {
 
     // Ensure ready completes immediately
     expect(
-        watcher.ready.timeout(new Duration(milliseconds: 0),
+        watcher.ready.timeout(Duration(milliseconds: 0),
             onTimeout: () => throw 'Does not complete immedately'),
         completes);
   });

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -61,13 +61,13 @@ Future<Null> startWatcher({String path}) async {
     assert(p.isRelative(path) && !path.startsWith(".."));
 
     var mtime = _mockFileModificationTimes[path];
-    return new DateTime.fromMillisecondsSinceEpoch(mtime ?? 0);
+    return DateTime.fromMillisecondsSinceEpoch(mtime ?? 0);
   });
 
   // We want to wait until we're ready *after* we subscribe to the watcher's
   // events.
   var watcher = createWatcher(path: path);
-  _watcherEvents = new StreamQueue(watcher.events);
+  _watcherEvents = StreamQueue(watcher.events);
   // Forces a subscription to the underlying stream.
   _watcherEvents.hasNext;
   await watcher.ready;
@@ -93,7 +93,7 @@ List<StreamMatcher> _collectedStreamMatchers;
 /// The returned matcher will match each of the collected matchers in order.
 StreamMatcher _collectStreamMatcher(block()) {
   var oldStreamMatchers = _collectedStreamMatchers;
-  _collectedStreamMatchers = new List<StreamMatcher>();
+  _collectedStreamMatchers = List<StreamMatcher>();
   try {
     block();
     return emitsInOrder(_collectedStreamMatchers);
@@ -207,12 +207,12 @@ void writeFile(String path, {String contents, bool updateModified}) {
   var fullPath = p.join(d.sandbox, path);
 
   // Create any needed subdirectories.
-  var dir = new Directory(p.dirname(fullPath));
+  var dir = Directory(p.dirname(fullPath));
   if (!dir.existsSync()) {
     dir.createSync(recursive: true);
   }
 
-  new File(fullPath).writeAsStringSync(contents);
+  File(fullPath).writeAsStringSync(contents);
 
   if (updateModified) {
     path = p.normalize(path);
@@ -224,12 +224,12 @@ void writeFile(String path, {String contents, bool updateModified}) {
 
 /// Schedules deleting a file in the sandbox at [path].
 void deleteFile(String path) {
-  new File(p.join(d.sandbox, path)).deleteSync();
+  File(p.join(d.sandbox, path)).deleteSync();
 }
 
 /// Schedules renaming a file in the sandbox from [from] to [to].
 void renameFile(String from, String to) {
-  new File(p.join(d.sandbox, from)).renameSync(p.join(d.sandbox, to));
+  File(p.join(d.sandbox, from)).renameSync(p.join(d.sandbox, to));
 
   // Make sure we always use the same separator on Windows.
   to = p.normalize(to);
@@ -240,17 +240,17 @@ void renameFile(String from, String to) {
 
 /// Schedules creating a directory in the sandbox at [path].
 void createDir(String path) {
-  new Directory(p.join(d.sandbox, path)).createSync();
+  Directory(p.join(d.sandbox, path)).createSync();
 }
 
 /// Schedules renaming a directory in the sandbox from [from] to [to].
 void renameDir(String from, String to) {
-  new Directory(p.join(d.sandbox, from)).renameSync(p.join(d.sandbox, to));
+  Directory(p.join(d.sandbox, from)).renameSync(p.join(d.sandbox, to));
 }
 
 /// Schedules deleting a directory in the sandbox at [path].
 void deleteDir(String path) {
-  new Directory(p.join(d.sandbox, path)).deleteSync(recursive: true);
+  Directory(p.join(d.sandbox, path)).deleteSync(recursive: true);
 }
 
 /// Runs [callback] with every permutation of non-negative numbers for each
@@ -261,7 +261,7 @@ void deleteDir(String path) {
 /// [limit] defaults to 3.
 Set<S> withPermutations<S>(S callback(int i, int j, int k), {int limit}) {
   if (limit == null) limit = 3;
-  var results = new Set<S>();
+  var results = Set<S>();
   for (var i = 0; i < limit; i++) {
     for (var j = 0; j < limit; j++) {
       for (var k = 0; k < limit; k++) {


### PR DESCRIPTION
Drops optional `new` and `const`

Bump SDK constraint to `2.0.0` to ensure compatibility with omitted
`new`.