### PR TITLE
Catch FileSystemException during existsSync() on Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.7+12
+
+* Catch `FileSystemException` during `existsSync()` on Windows.
+
 # 0.9.7+11
 
 * Fix an analysis hint.

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -308,8 +308,8 @@ class _WindowsDirectoryWatcher
     }
   }
 
-  /// Returns one or more events that describe the change between the last known
-  /// state of [path] and its current state on the filesystem.
+  /// Returns zero or more events that describe the change between the last
+  /// known state of [path] and its current state on the filesystem.
   ///
   /// This returns a list whose order should be reflected in the events emitted
   /// to the user, unlike the batched events from [Directory.watch]. The
@@ -318,8 +318,15 @@ class _WindowsDirectoryWatcher
   List<FileSystemEvent> _eventsBasedOnFileSystem(String path) {
     var fileExisted = _files.contains(path);
     var dirExisted = _files.containsDir(path);
-    var fileExists = File(path).existsSync();
-    var dirExists = Directory(path).existsSync();
+
+    bool fileExists;
+    bool dirExists;
+    try {
+      fileExists = File(path).existsSync();
+      dirExists = Directory(path).existsSync();
+    } on FileSystemException {
+      return const <FileSystemEvent>[];
+    }
 
     var events = <FileSystemEvent>[];
     if (fileExisted) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 0.9.7+11
+version: 0.9.7+12
 
 description: >
   A file system watcher. It monitors changes to contents of directories and


### PR DESCRIPTION
Context: https://github.com/dart-lang/sdk/issues/34294

Translation of the error: `access denied`.