### PR TITLE
Handle file watcher closed exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.7+13
+
+* Catch & forward `FileSystemException` from unexpectedly closed file watchers
+  on windows; the watcher will also be automatically restarted when this occurs.
+
 # 0.9.7+12
 
 * Catch `FileSystemException` during `existsSync()` on Windows.

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -372,22 +372,18 @@ class _WindowsDirectoryWatcher
 
   /// Start or restart the underlying [Directory.watch] stream.
   void _startWatch() {
-    startInnerStream() {
-      // Batch the events together so that we can dedup events.
+    // Note: "watcher closed" exceptions do not get sent over the stream
+    // returned by watch, and must be caught via a zone handler.
+    runZoned(() {
       var innerStream = Directory(path).watch(recursive: true);
       _watchSubscription = innerStream.listen(_onEvent,
           onError: _eventsController.addError, onDone: _onDone);
-    }
-
-    // Start a zone to catch "Directory watcher closed unexpectedly."
-    runZoned(() {
-      startInnerStream();
     }, onError: (error, StackTrace stackTrace) {
       if (error is FileSystemException &&
           error.message.startsWith('Directory watcher closed unexpectedly')) {
+        _watchSubscription.cancel();
         _eventsController.addError(error, stackTrace);
-        // Restart the inner stream.
-        startInnerStream();
+        _startWatch();
       } else {
         throw error;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 0.9.7+12
+version: 0.9.7+13
 
 description: >-
   A file system watcher. It monitors changes to contents of directories and


### PR DESCRIPTION
A better fix for #52 than nothing.

The exception for an unexpectedly closed watcher on windows due to buffer overflow does *not* get returned on the watcher stream itself. It must be caught with a zone handler: https://github.com/dart-lang/sdk/issues/37233#issuecomment-540659282

This is obviously not ideal. This could be fixed in the SDK itself, however, it is reasonable for package:watcher to handle this quirk like it handles many other. If it gets changed in the SDK this could be dropped when package:watcher depends on that fixed SDK.

In tests, this error handler in package:build does not fire for the unexpectedly closed watcher (https://github.com/dart-lang/build/pull/2505/files#diff-bb055e910a47d24fa146009d257f5946R57) and in the analysis server we are getting these exceptions (https://github.com/dart-lang/sdk/issues/38853) despite a similar handleError call we also have, here: https://github.com/dart-lang/sdk/blob/master/pkg/analyzer/lib/file_system/physical_file_system.dart#L264