### PR TITLE
Temporarily disable comment_references lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,7 +11,7 @@ analyzer:
 
 linter:
   rules:
-    - comment_references
+    # comment_references # https://github.com/dart-lang/sdk/issues/39467
     - prefer_generic_function_type_aliases
     - prefer_typing_uninitialized_variables
     - unnecessary_const


### PR DESCRIPTION
There was a regression in the SDK and some references that used to be
valid, and should still work in Dart doc, are marked invalid.

See https://github.com/dart-lang/sdk/issues/39467