### PR TITLE
Check for FileSystemEntityType.notFound

### DIFF
--- a/lib/src/stat.dart
+++ b/lib/src/stat.dart
@@ -28,5 +28,6 @@ Future<DateTime> modificationTime(String path) async {
   }
 
   final stat = await FileStat.stat(path);
+  if (stat.type == FileSystemEntityType.notFound) return null;
   return stat.modified;
 }


### PR DESCRIPTION
The Dart breaking change <https://github.com/dart-lang/sdk/issues/40706> will change the timestamps on the notFound object from null to the epoch timestamp. This change updates package:watcher accordingly. The change is backwards compatible and forwards compatible.

This pull requests blocks the <https://github.com/dart-lang/sdk/issues/40706> breaking change which blocks the Dart SDK NNBD unfork. Please review and commit the change if you approve, and then please make a package:watcher release on pub. We'll then want the change to roll into G3 and Dart/Flutter.