### PR TITLE
Prepare to publish, tighten pub constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.9.7+14
+
+* Prepare for breaking change in SDK where modified times for not found files
+  becomes meaningless instead of null.
+
 # 0.9.7+13
 
 * Catch & forward `FileSystemException` from unexpectedly closed file watchers

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,20 @@
 name: watcher
-version: 0.9.7+14-dev
+version: 0.9.7+14
 
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/watcher
 
 environment:
   sdk: '>=2.2.0 <3.0.0'
 
 dependencies:
-  async: '>=1.10.0 <3.0.0'
-  path: '>=0.9.0 <2.0.0'
+  async: ^2.0.0
+  path: ^1.0.0
   pedantic: ^1.1.0
 
 dev_dependencies:
   benchmark_harness: ^1.0.4
-  test: '>=0.12.42 <2.0.0'
+  test: ^1.0.0
   test_descriptor: ^1.0.0


### PR DESCRIPTION
- Add a changelog entry.
- Remove unused author key from pubspec.
- Tighten the constraints on dependencies for any which had a lower
  major version bound than the package versions which support Dart 2.