### PR TITLE
Make watcher use runZonedGuarded.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: dart
 
 dart:
 - dev
-- 2.2.0
 
 dart_task:
 - test

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -381,11 +381,11 @@ class _WindowsDirectoryWatcher
   void _startWatch() {
     // Note: "watcher closed" exceptions do not get sent over the stream
     // returned by watch, and must be caught via a zone handler.
-    runZoned(() {
+    runZonedGuarded(() {
       var innerStream = Directory(path).watch(recursive: true);
       _watchSubscription = innerStream.listen(_onEvent,
           onError: _eventsController.addError, onDone: _onDone);
-    }, onError: (error, StackTrace stackTrace) {
+    }, (error, StackTrace stackTrace) {
       if (error is FileSystemException &&
           error.message.startsWith('Directory watcher closed unexpectedly')) {
         _watchSubscription.cancel();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: watcher
-version: 0.9.7+14
+version: 0.9.7+15
 
 description: >-
   A file system watcher. It monitors changes to contents of directories and
@@ -7,7 +7,7 @@ description: >-
 homepage: https://github.com/dart-lang/watcher
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.8.0-dev <3.0.0'
 
 dependencies:
   async: ^2.0.0


### PR DESCRIPTION
This package is depended on by the Dart SDK. This prepares it for
the release of Dart 2.8 which has a breaking change around runZoned.
The SDK version should be set to 2.8.0 before publishing.