### PR TITLE
Add a reason to a flaky assert

### DIFF
--- a/test/utils.dart
+++ b/test/utils.dart
@@ -55,13 +55,13 @@ StreamQueue<WatchEvent> _watcherEvents;
 /// If [path] is provided, watches a path in the sandbox with that name.
 Future<Null> startWatcher({String path}) async {
   mockGetModificationTime((path) {
-    path = p.normalize(p.relative(path, from: d.sandbox));
+    final normalized = p.normalize(p.relative(path, from: d.sandbox));
 
     // Make sure we got a path in the sandbox.
-    assert(p.isRelative(path) && !path.startsWith('..'),
-        'Path is not in the sandbox: $path');
+    assert(p.isRelative(normalized) && !normalized.startsWith('..'),
+        'Path is not in the sandbox: $path not in ${d.sandbox}');
 
-    var mtime = _mockFileModificationTimes[path];
+    var mtime = _mockFileModificationTimes[normalized];
     return DateTime.fromMillisecondsSinceEpoch(mtime ?? 0);
   });
 

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -58,7 +58,8 @@ Future<Null> startWatcher({String path}) async {
     path = p.normalize(p.relative(path, from: d.sandbox));
 
     // Make sure we got a path in the sandbox.
-    assert(p.isRelative(path) && !path.startsWith('..'));
+    assert(p.isRelative(path) && !path.startsWith('..'),
+        'Path is not in the sandbox: $path');
 
     var mtime = _mockFileModificationTimes[path];
     return DateTime.fromMillisecondsSinceEpoch(mtime ?? 0);


### PR DESCRIPTION
We have seen a case of this assert failing on linux on travis. Add a
reason which includes the path to hopefully get more information if we
see it again.