### PR TITLE
Implement the ability to register custom watcher implementations

### DIFF
--- a/lib/src/custom_watcher_factory.dart
+++ b/lib/src/custom_watcher_factory.dart
@@ -1,0 +1,46 @@
+import '../watcher.dart';
+
+/// Defines a way to create a custom watcher instead of the default ones.
+///
+/// This will be used when a [DirectoryWatcher] or [FileWatcher] would be
+/// created and will take precedence over the default ones.
+abstract class CustomWatcherFactory {
+  /// Uniquely identify this watcher.
+  String get id;
+
+  /// Tries to create a [DirectoryWatcher] for the provided path.
+  ///
+  /// Should return `null` if the path is not supported by this factory.
+  DirectoryWatcher createDirectoryWatcher(String path, {Duration pollingDelay});
+
+  /// Tries to create a [FileWatcher] for the provided path.
+  ///
+  /// Should return `null` if the path is not supported by this factory.
+  FileWatcher createFileWatcher(String path, {Duration pollingDelay});
+}
+
+/// Registers a custom watcher.
+///
+/// It's only allowed to register a watcher once per [id]. The [supportsPath]
+/// will be called to determine if the [createWatcher] should be used instead of
+/// the built-in watchers.
+///
+/// Note that we will try [CustomWatcherFactory] one by one in the order they
+/// were registered.
+void registerCustomWatcherFactory(CustomWatcherFactory customFactory) {
+  if (_customWatcherFactories.containsKey(customFactory.id)) {
+    throw ArgumentError('A custom watcher with id `${customFactory.id}` '
+        'has already been registered');
+  }
+  _customWatcherFactories[customFactory.id] = customFactory;
+}
+
+/// Unregisters a custom watcher and returns it (returns `null` if it was never
+/// registered).
+CustomWatcherFactory unregisterCustomWatcherFactory(String id) =>
+    _customWatcherFactories.remove(id);
+
+Iterable<CustomWatcherFactory> get customWatcherFactories =>
+    _customWatcherFactories.values;
+
+final _customWatcherFactories = <String, CustomWatcherFactory>{};

--- a/lib/src/custom_watcher_factory.dart
+++ b/lib/src/custom_watcher_factory.dart
@@ -10,23 +10,20 @@ abstract class CustomWatcherFactory {
 
   /// Tries to create a [DirectoryWatcher] for the provided path.
   ///
-  /// Should return `null` if the path is not supported by this factory.
+  /// Returns `null` if the path is not supported by this factory.
   DirectoryWatcher createDirectoryWatcher(String path, {Duration pollingDelay});
 
   /// Tries to create a [FileWatcher] for the provided path.
   ///
-  /// Should return `null` if the path is not supported by this factory.
+  /// Returns `null` if the path is not supported by this factory.
   FileWatcher createFileWatcher(String path, {Duration pollingDelay});
 }
 
 /// Registers a custom watcher.
 ///
-/// It's only allowed to register a watcher once per [id]. The [supportsPath]
-/// will be called to determine if the [createWatcher] should be used instead of
-/// the built-in watchers.
-///
-/// Note that we will try [CustomWatcherFactory] one by one in the order they
-/// were registered.
+/// It's only allowed to register a watcher factory once per [id] and at most
+/// one factory should apply to any given file (creating a [Watcher] will fail
+/// otherwise).
 void registerCustomWatcherFactory(CustomWatcherFactory customFactory) {
   if (_customWatcherFactories.containsKey(customFactory.id)) {
     throw ArgumentError('A custom watcher with id `${customFactory.id}` '
@@ -35,8 +32,48 @@ void registerCustomWatcherFactory(CustomWatcherFactory customFactory) {
   _customWatcherFactories[customFactory.id] = customFactory;
 }
 
-/// Unregisters a custom watcher and returns it (returns `null` if it was never
-/// registered).
+/// Tries to create a custom [DirectoryWatcher] and returns it.
+///
+/// Returns `null` if no custom watcher was applicable and throws a [StateError]
+/// if more than one was.
+DirectoryWatcher createCustomDirectoryWatcher(String path,
+    {Duration pollingDelay}) {
+  DirectoryWatcher customWatcher;
+  String customFactoryId;
+  for (var watcherFactory in customWatcherFactories) {
+    if (customWatcher != null) {
+      throw StateError('Two `CustomWatcherFactory`s applicable: '
+          '`$customFactoryId` and `${watcherFactory.id}` for `$path`');
+    }
+    customWatcher =
+        watcherFactory.createDirectoryWatcher(path, pollingDelay: pollingDelay);
+    customFactoryId = watcherFactory.id;
+  }
+  return customWatcher;
+}
+
+/// Tries to create a custom [FileWatcher] and returns it.
+///
+/// Returns `null` if no custom watcher was applicable and throws a [StateError]
+/// if more than one was.
+FileWatcher createCustomFileWatcher(String path, {Duration pollingDelay}) {
+  FileWatcher customWatcher;
+  String customFactoryId;
+  for (var watcherFactory in customWatcherFactories) {
+    if (customWatcher != null) {
+      throw StateError('Two `CustomWatcherFactory`s applicable: '
+          '`$customFactoryId` and `${watcherFactory.id}` for `$path`');
+    }
+    customWatcher =
+        watcherFactory.createFileWatcher(path, pollingDelay: pollingDelay);
+    customFactoryId = watcherFactory.id;
+  }
+  return customWatcher;
+}
+
+/// Unregisters a custom watcher and returns it.
+///
+/// Returns `null` if the id was never registered.
 CustomWatcherFactory unregisterCustomWatcherFactory(String id) =>
     _customWatcherFactories.remove(id);
 

--- a/lib/src/directory_watcher.dart
+++ b/lib/src/directory_watcher.dart
@@ -5,10 +5,11 @@
 import 'dart:io';
 
 import '../watcher.dart';
+import 'custom_watcher_factory.dart';
 import 'directory_watcher/linux.dart';
 import 'directory_watcher/mac_os.dart';
-import 'directory_watcher/windows.dart';
 import 'directory_watcher/polling.dart';
+import 'directory_watcher/windows.dart';
 
 /// Watches the contents of a directory and emits [WatchEvent]s when something
 /// in the directory has changed.
@@ -29,6 +30,14 @@ abstract class DirectoryWatcher implements Watcher {
   /// watchers.
   factory DirectoryWatcher(String directory, {Duration pollingDelay}) {
     if (FileSystemEntity.isWatchSupported) {
+      for (var custom in customWatcherFactories) {
+        var watcher = custom.createDirectoryWatcher(directory,
+            pollingDelay: pollingDelay);
+        if (watcher != null) {
+          return watcher;
+        }
+      }
+
       if (Platform.isLinux) return LinuxDirectoryWatcher(directory);
       if (Platform.isMacOS) return MacOSDirectoryWatcher(directory);
       if (Platform.isWindows) return WindowsDirectoryWatcher(directory);

--- a/lib/src/directory_watcher.dart
+++ b/lib/src/directory_watcher.dart
@@ -30,14 +30,9 @@ abstract class DirectoryWatcher implements Watcher {
   /// watchers.
   factory DirectoryWatcher(String directory, {Duration pollingDelay}) {
     if (FileSystemEntity.isWatchSupported) {
-      for (var custom in customWatcherFactories) {
-        var watcher = custom.createDirectoryWatcher(directory,
-            pollingDelay: pollingDelay);
-        if (watcher != null) {
-          return watcher;
-        }
-      }
-
+      var customWatcher =
+          createCustomDirectoryWatcher(directory, pollingDelay: pollingDelay);
+      if (customWatcher != null) return customWatcher;
       if (Platform.isLinux) return LinuxDirectoryWatcher(directory);
       if (Platform.isMacOS) return MacOSDirectoryWatcher(directory);
       if (Platform.isWindows) return WindowsDirectoryWatcher(directory);

--- a/lib/src/file_watcher.dart
+++ b/lib/src/file_watcher.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import '../watcher.dart';
+import 'custom_watcher_factory.dart';
 import 'file_watcher/native.dart';
 import 'file_watcher/polling.dart';
 
@@ -29,6 +30,13 @@ abstract class FileWatcher implements Watcher {
   /// and higher CPU usage. Defaults to one second. Ignored for non-polling
   /// watchers.
   factory FileWatcher(String file, {Duration pollingDelay}) {
+    for (var custom in customWatcherFactories) {
+      var watcher = custom.createFileWatcher(file, pollingDelay: pollingDelay);
+      if (watcher != null) {
+        return watcher;
+      }
+    }
+
     // [File.watch] doesn't work on Windows, but
     // [FileSystemEntity.isWatchSupported] is still true because directory
     // watching does work.

--- a/lib/src/file_watcher.dart
+++ b/lib/src/file_watcher.dart
@@ -30,12 +30,9 @@ abstract class FileWatcher implements Watcher {
   /// and higher CPU usage. Defaults to one second. Ignored for non-polling
   /// watchers.
   factory FileWatcher(String file, {Duration pollingDelay}) {
-    for (var custom in customWatcherFactories) {
-      var watcher = custom.createFileWatcher(file, pollingDelay: pollingDelay);
-      if (watcher != null) {
-        return watcher;
-      }
-    }
+    var customWatcher =
+        createCustomFileWatcher(file, pollingDelay: pollingDelay);
+    if (customWatcher != null) return customWatcher;
 
     // [File.watch] doesn't work on Windows, but
     // [FileSystemEntity.isWatchSupported] is still true because directory

--- a/lib/watcher.dart
+++ b/lib/watcher.dart
@@ -5,15 +5,20 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'src/watch_event.dart';
 import 'src/directory_watcher.dart';
 import 'src/file_watcher.dart';
+import 'src/watch_event.dart';
 
-export 'src/watch_event.dart';
+export 'src/custom_watcher_factory.dart'
+    show
+        CustomWatcherFactory,
+        registerCustomWatcherFactory,
+        unregisterCustomWatcherFactory;
 export 'src/directory_watcher.dart';
 export 'src/directory_watcher/polling.dart';
 export 'src/file_watcher.dart';
 export 'src/file_watcher/polling.dart';
+export 'src/watch_event.dart';
 
 abstract class Watcher {
   /// The path to the file or directory whose contents are being monitored.

--- a/test/custom_watcher_factory_test.dart
+++ b/test/custom_watcher_factory_test.dart
@@ -82,7 +82,9 @@ class _MemFs {
 
   StreamController<WatchEvent> watchStream(String path) {
     var controller = StreamController<WatchEvent>();
-    _streams.putIfAbsent(path, () => {}).add(controller);
+    _streams
+        .putIfAbsent(path, () => <StreamController<WatchEvent>>{})
+        .add(controller);
     return controller;
   }
 
@@ -128,6 +130,7 @@ class _MemFsWatcher implements FileWatcher, DirectoryWatcher, Watcher {
 }
 
 class _MemFsWatcherFactory implements CustomWatcherFactory {
+  @override
   final String id;
   final _MemFs _memFs;
   _MemFsWatcherFactory(this.id, this._memFs);

--- a/test/custom_watcher_factory_test.dart
+++ b/test/custom_watcher_factory_test.dart
@@ -1,0 +1,130 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:watcher/watcher.dart';
+
+void main() {
+  _MemFs memFs;
+
+  setUp(() {
+    memFs = _MemFs();
+    registerCustomWatcherFactory(_MemFsWatcherFactory(memFs));
+  });
+
+  tearDown(() async {
+    unregisterCustomWatcherFactory('MemFs');
+  });
+
+  test('notifes for files', () async {
+    var watcher = FileWatcher('file.txt');
+
+    var completer = Completer<WatchEvent>();
+    watcher.events.listen((event) => completer.complete(event));
+    await watcher.ready;
+    memFs.add('file.txt');
+    var event = await completer.future;
+
+    expect(event.type, ChangeType.ADD);
+    expect(event.path, 'file.txt');
+  });
+
+  test('notifes for directories', () async {
+    var watcher = DirectoryWatcher('dir');
+
+    var completer = Completer<WatchEvent>();
+    watcher.events.listen((event) => completer.complete(event));
+    await watcher.ready;
+    memFs.add('dir');
+    var event = await completer.future;
+
+    expect(event.type, ChangeType.ADD);
+    expect(event.path, 'dir');
+  });
+
+  test('unregister works', () async {
+    var memFactory = _MemFsWatcherFactory(memFs);
+    unregisterCustomWatcherFactory(memFactory.id);
+
+    var completer = Completer<dynamic>();
+    var watcher = FileWatcher('file.txt');
+    watcher.events.listen((e) {}, onError: (e) => completer.complete(e));
+    await watcher.ready;
+    memFs.add('file.txt');
+    var result = await completer.future;
+
+    expect(result, isA<FileSystemException>());
+  });
+
+  test('registering twice throws', () async {
+    expect(() => registerCustomWatcherFactory(_MemFsWatcherFactory(memFs)),
+        throwsA(isA<ArgumentError>()));
+  });
+}
+
+class _MemFs {
+  final _streams = <String, Set<StreamController<WatchEvent>>>{};
+
+  StreamController<WatchEvent> watchStream(String path) {
+    var controller = StreamController<WatchEvent>();
+    _streams.putIfAbsent(path, () => {}).add(controller);
+    return controller;
+  }
+
+  void add(String path) {
+    var controllers = _streams[path];
+    if (controllers != null) {
+      for (var controller in controllers) {
+        controller.add(WatchEvent(ChangeType.ADD, path));
+      }
+    }
+  }
+
+  void remove(String path) {
+    var controllers = _streams[path];
+    if (controllers != null) {
+      for (var controller in controllers) {
+        controller.add(WatchEvent(ChangeType.REMOVE, path));
+      }
+    }
+  }
+}
+
+class _MemFsWatcher implements FileWatcher, DirectoryWatcher, Watcher {
+  final String _path;
+  final StreamController<WatchEvent> _controller;
+
+  _MemFsWatcher(this._path, this._controller);
+
+  @override
+  String get path => _path;
+
+  @override
+  String get directory => throw UnsupportedError('directory is not supported');
+
+  @override
+  Stream<WatchEvent> get events => _controller.stream;
+
+  @override
+  bool get isReady => true;
+
+  @override
+  Future<void> get ready async {}
+}
+
+class _MemFsWatcherFactory implements CustomWatcherFactory {
+  final _MemFs _memFs;
+  _MemFsWatcherFactory(this._memFs);
+
+  @override
+  String get id => 'MemFs';
+
+  @override
+  DirectoryWatcher createDirectoryWatcher(String path,
+          {Duration pollingDelay}) =>
+      _MemFsWatcher(path, _memFs.watchStream(path));
+
+  @override
+  FileWatcher createFileWatcher(String path, {Duration pollingDelay}) =>
+      _MemFsWatcher(path, _memFs.watchStream(path));
+}

--- a/test/custom_watcher_factory_test.dart
+++ b/test/custom_watcher_factory_test.dart
@@ -46,14 +46,16 @@ void main() {
     var memFactory = _MemFsWatcherFactory(memFs);
     unregisterCustomWatcherFactory(memFactory.id);
 
-    var completer = Completer<dynamic>();
+    var events = <WatchEvent>[];
     var watcher = FileWatcher('file.txt');
-    watcher.events.listen((e) {}, onError: (e) => completer.complete(e));
+    watcher.events.listen((e) => events.add(e));
     await watcher.ready;
-    memFs.add('file.txt');
-    var result = await completer.future;
+    memFs.add('a.txt');
+    memFs.add('b.txt');
+    memFs.add('c.txt');
+    await Future.delayed(Duration(seconds: 1));
 
-    expect(result, isA<FileSystemException>());
+    expect(events, isEmpty);
   });
 
   test('registering twice throws', () async {


### PR DESCRIPTION
Currently to handle special file systems, we need to internally patch the package to create specialized `Watcher`s. This change allows to dynamically register a `Watcher` factory that will take precedence over the default options. The applications could then "register" such factories as needed.

CC @davidmorgan 