### PR TITLE
Expose a smaller surface area for custom watchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.9.8
+
+* Add the ability to create custom Watcher types for specific file paths.
+
 # 0.9.7+15
 
 * Fix a bug on Mac where modifying a directory with a path exactly matching a

--- a/lib/watcher.dart
+++ b/lib/watcher.dart
@@ -9,11 +9,7 @@ import 'src/directory_watcher.dart';
 import 'src/file_watcher.dart';
 import 'src/watch_event.dart';
 
-export 'src/custom_watcher_factory.dart'
-    show
-        CustomWatcherFactory,
-        registerCustomWatcherFactory,
-        unregisterCustomWatcherFactory;
+export 'src/custom_watcher_factory.dart' show registerCustomWatcher;
 export 'src/directory_watcher.dart';
 export 'src/directory_watcher/polling.dart';
 export 'src/file_watcher.dart';


### PR DESCRIPTION
- Remove the function to unregister a custom watcher, we can add it
  later when we have a specific use case for it.
- Remove the class `CustomFactoryWatcher` and take callbacks instead.
- Bump the version and add the changelog that was missed.
- Add missing copyright notice.