### PR TITLE
Remove unused dart:async import

### DIFF
--- a/lib/src/async_queue.dart
+++ b/lib/src/async_queue.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:collection';
 
 typedef ItemProcessor<T> = Future<void> Function(T item);

--- a/lib/src/stat.dart
+++ b/lib/src/stat.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 /// A function that takes a file path and returns the last modified time for

--- a/lib/watcher.dart
+++ b/lib/watcher.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'src/directory_watcher.dart';


### PR DESCRIPTION
The only members of dart:async used here (Future and/or Stream) are exported from dart:core now.