### PR TITLE
Remove an inferrable argument type

### DIFF
--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -383,7 +383,7 @@ class _WindowsDirectoryWatcher
       var innerStream = Directory(path).watch(recursive: true);
       _watchSubscription = innerStream.listen(_onEvent,
           onError: _eventsController.addError, onDone: _onDone);
-    }, (error, StackTrace stackTrace) {
+    }, (error, stackTrace) {
       if (error is FileSystemException &&
           error.message.startsWith('Directory watcher closed unexpectedly')) {
         _watchSubscription.cancel();


### PR DESCRIPTION
The `runZonedGuarded` API has a more specific static type which allows
argument types for function literals to be inferred.