### PR TITLE
remove a 200ms delay in sending events

### DIFF
--- a/test/directory_watcher/shared.dart
+++ b/test/directory_watcher/shared.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:test/test.dart';
 import 'package:watcher/src/utils.dart';
 
@@ -76,6 +78,11 @@ void sharedTests() {
     writeFile('dir/a.txt');
     writeFile('dir/b.txt');
 
+    // TODO: This is a workaround for https://github.com/dart-lang/sdk/issues/14373.
+    if (Platform.isMacOS) {
+      await Future.delayed(Duration(milliseconds: 200));
+    }
+
     await startWatcher(path: 'dir');
 
     renameDir('dir', 'moved_dir');
@@ -89,6 +96,11 @@ void sharedTests() {
       'is added', () async {
     writeFile('dir/a.txt');
     writeFile('dir/b.txt');
+
+    // TODO: This is a workaround for https://github.com/dart-lang/sdk/issues/14373.
+    if (Platform.isMacOS) {
+      await Future.delayed(Duration(milliseconds: 200));
+    }
 
     await startWatcher(path: 'dir');
 


### PR DESCRIPTION
- remove a 200ms delay in sending events

This removes an artificial 200ms delay where, after subscribing to a watcher, any file change events received in the first 200ms are discarded.

Because of https://github.com/dart-lang/sdk/issues/14373, this will mean that on macos, when you subscribe to changes, your might receive file change events that happened immediately before your subscription. (the 'bogus events' discussed in the deleted comments below). On the whole I believe this is a better compromise than discarding change events.

If this looks good I can update the changelog and pubspec appropriately.
