### PR TITLE
Add a new `forcePollingWatcher` option when creating watchers.

### DIFF
--- a/lib/src/directory_watcher.dart
+++ b/lib/src/directory_watcher.dart
@@ -19,16 +19,18 @@ abstract class DirectoryWatcher implements Watcher {
 
   /// Creates a new [DirectoryWatcher] monitoring [directory].
   ///
-  /// If a native directory watcher is available for this platform, this will
-  /// use it. Otherwise, it will fall back to a [PollingDirectoryWatcher].
+  /// If a native directory watcher is available for this platform, and if
+  /// [forcePollingWatcher] is not set to true, this will use a native watcher.
+  /// Otherwise, it will fall back to a [PollingDirectoryWatcher].
   ///
   /// If [pollingDelay] is passed, it specifies the amount of time the watcher
   /// will pause between successive polls of the directory contents. Making this
   /// shorter will give more immediate feedback at the expense of doing more IO
   /// and higher CPU usage. Defaults to one second. Ignored for non-polling
   /// watchers.
-  factory DirectoryWatcher(String directory, {Duration? pollingDelay}) {
-    if (FileSystemEntity.isWatchSupported) {
+  factory DirectoryWatcher(String directory,
+      {Duration? pollingDelay, bool forcePollingWatcher = false}) {
+    if (FileSystemEntity.isWatchSupported && !forcePollingWatcher) {
       var customWatcher =
           createCustomDirectoryWatcher(directory, pollingDelay: pollingDelay);
       if (customWatcher != null) return customWatcher;

--- a/lib/src/file_watcher.dart
+++ b/lib/src/file_watcher.dart
@@ -19,7 +19,8 @@ import 'file_watcher/native.dart';
 abstract class FileWatcher implements Watcher {
   /// Creates a new [FileWatcher] monitoring [file].
   ///
-  /// If a native file watcher is available for this platform, this will use it.
+  /// If a native file watcher is available for this platform, and if
+  /// [forcePollingWatcher] is not set to true, this will use a native watcher.
   /// Otherwise, it will fall back to a [PollingFileWatcher]. Notably, native
   /// file watching is *not* supported on Windows.
   ///
@@ -28,7 +29,7 @@ abstract class FileWatcher implements Watcher {
   /// shorter will give more immediate feedback at the expense of doing more IO
   /// and higher CPU usage. Defaults to one second. Ignored for non-polling
   /// watchers.
-  factory FileWatcher(String file, {Duration? pollingDelay}) {
+  factory FileWatcher(String file, {Duration? pollingDelay, bool forcePollingWatcher = false}) {
     var customWatcher =
         createCustomFileWatcher(file, pollingDelay: pollingDelay);
     if (customWatcher != null) return customWatcher;
@@ -36,7 +37,7 @@ abstract class FileWatcher implements Watcher {
     // [File.watch] doesn't work on Windows, but
     // [FileSystemEntity.isWatchSupported] is still true because directory
     // watching does work.
-    if (FileSystemEntity.isWatchSupported && !Platform.isWindows) {
+    if (FileSystemEntity.isWatchSupported && !Platform.isWindows && !forcePollingWatcher) {
       return NativeFileWatcher(file);
     }
     return PollingFileWatcher(file, pollingDelay: pollingDelay);

--- a/lib/watcher.dart
+++ b/lib/watcher.dart
@@ -47,7 +47,8 @@ abstract class Watcher {
   /// Creates a new [DirectoryWatcher] or [FileWatcher] monitoring [path],
   /// depending on whether it's a file or directory.
   ///
-  /// If a native watcher is available for this platform, this will use it.
+  /// If a native watcher is available for this platform, and if
+  /// [forcePollingWatcher] is not set to true, this will use a native watcher.
   /// Otherwise, it will fall back to a polling watcher. Notably, watching
   /// individual files is not natively supported on Windows, although watching
   /// directories is.
@@ -57,9 +58,11 @@ abstract class Watcher {
   /// shorter will give more immediate feedback at the expense of doing more IO
   /// and higher CPU usage. Defaults to one second. Ignored for non-polling
   /// watchers.
-  factory Watcher(String path, {Duration? pollingDelay}) {
+  factory Watcher(String path,
+      {Duration? pollingDelay, bool forcePollingWatcher = false}) {
     if (File(path).existsSync()) {
-      return FileWatcher(path, pollingDelay: pollingDelay);
+      return FileWatcher(path,
+          pollingDelay: pollingDelay, forcePollingWatcher: forcePollingWatcher);
     } else {
       return DirectoryWatcher(path, pollingDelay: pollingDelay);
     }

--- a/test/directory_watcher/linux_test.dart
+++ b/test/directory_watcher/linux_test.dart
@@ -6,6 +6,7 @@
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/linux.dart';
+import 'package:watcher/src/directory_watcher/polling.dart';
 import 'package:watcher/watcher.dart';
 
 import 'shared.dart';
@@ -18,6 +19,11 @@ void main() {
 
   test('DirectoryWatcher creates a LinuxDirectoryWatcher on Linux', () {
     expect(DirectoryWatcher('.'), TypeMatcher<LinuxDirectoryWatcher>());
+  });
+
+  test('DirectoryWatcher creates a PollingDirectoryWatcher when forced', () {
+    expect(DirectoryWatcher('.', forcePollingWatcher: true),
+        TypeMatcher<PollingDirectoryWatcher>());
   });
 
   test('emits events for many nested files moved out then immediately back in',

--- a/test/file_watcher/native_test.dart
+++ b/test/file_watcher/native_test.dart
@@ -5,7 +5,9 @@
 @TestOn('linux || mac-os')
 
 import 'package:test/test.dart';
+import 'package:watcher/src/file_watcher.dart';
 import 'package:watcher/src/file_watcher/native.dart';
+import 'package:watcher/src/file_watcher/polling.dart';
 
 import 'shared.dart';
 import '../utils.dart';
@@ -15,6 +17,15 @@ void main() {
 
   setUp(() {
     writeFile('file.txt');
+  });
+
+  test('FileWatcher creates a NativeFileWatcher on supported platform', () {
+    expect(FileWatcher('file.txt'), TypeMatcher<NativeFileWatcher>());
+  });
+
+  test('FileWatcher creates a PollingFileWatcher when forced', () {
+    expect(FileWatcher('file.txt', forcePollingWatcher: true),
+        TypeMatcher<PollingFileWatcher>());
   });
 
   sharedTests();


### PR DESCRIPTION
On some filesystems, even when the system supports native watchers, a
specific filesystem might not. Allow the user to create polling watchers
in this case.

Context: b/197130363