### PR TITLE
Ensure ready future completes (with error) in the case the watcher fails and closes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.2-dev
 
 - Require Dart SDK >= 2.14
+- Ensure `DirectoryWatcher.ready` completes even when errors occur that close the watcher.
 
 # 1.0.1
 

--- a/lib/src/directory_watcher/linux.dart
+++ b/lib/src/directory_watcher/linux.dart
@@ -84,16 +84,23 @@ class _LinuxDirectoryWatcher
     var innerStream = _nativeEvents.stream.batchEvents();
     _listen(innerStream, _onBatch, onError: _eventsController.addError);
 
-    _listen(Directory(path).list(recursive: true), (FileSystemEntity entity) {
-      if (entity is Directory) {
-        _watchSubdir(entity.path);
-      } else {
-        _files.add(entity.path);
-      }
-    },
-        onError: _emitError,
-        onDone: _readyCompleter.complete,
-        cancelOnError: true);
+    _listen(
+      Directory(path).list(recursive: true),
+      (FileSystemEntity entity) {
+        if (entity is Directory) {
+          _watchSubdir(entity.path);
+        } else {
+          _files.add(entity.path);
+        }
+      },
+      onError: _emitError,
+      onDone: () {
+        if (!_readyCompleter.isCompleted) {
+          _readyCompleter.complete();
+        }
+      },
+      cancelOnError: true,
+    );
   }
 
   @override

--- a/lib/src/directory_watcher/linux.dart
+++ b/lib/src/directory_watcher/linux.dart
@@ -233,8 +233,7 @@ class _LinuxDirectoryWatcher
       // was added and then quickly removed.
       if (error is FileSystemException) return;
 
-      _eventsController.addError(error, stackTrace);
-      close();
+      _emitError(error, stackTrace);
     }, cancelOnError: true);
   }
 

--- a/lib/src/directory_watcher/mac_os.dart
+++ b/lib/src/directory_watcher/mac_os.dart
@@ -88,7 +88,7 @@ class _MacOSDirectoryWatcher
     // If we do receive a batch of events, [_onBatch] will ensure that these
     // futures don't fire and that the directory is re-listed.
     Future.wait([_listDir(), _waitForBogusEvents()]).then((_) {
-      if (!_readyCompleter.isCompleted) {
+      if (!isReady) {
         _readyCompleter.complete();
       }
     });
@@ -119,7 +119,7 @@ class _MacOSDirectoryWatcher
       // we can fire [ready] as soon as we're done listing the directory.
       _bogusEventTimer.cancel();
       _listDir().then((_) {
-        if (!_readyCompleter.isCompleted) {
+        if (!isReady) {
           _readyCompleter.complete();
         }
       });
@@ -404,8 +404,8 @@ class _MacOSDirectoryWatcher
   /// Emit an error, then close the watcher.
   void _emitError(Object error, StackTrace stackTrace) {
     // Guarantee that ready always completes.
-    if (!_readyCompleter.isCompleted) {
-      _readyCompleter.completeError(error);
+    if (!isReady) {
+      _readyCompleter.complete();
     }
     _eventsController.addError(error, stackTrace);
     close();

--- a/lib/src/directory_watcher/mac_os.dart
+++ b/lib/src/directory_watcher/mac_os.dart
@@ -396,6 +396,10 @@ class _MacOSDirectoryWatcher
 
   /// Emit an error, then close the watcher.
   void _emitError(Object error, StackTrace stackTrace) {
+    // Guarantee that ready always completes.
+    if (!_readyCompleter.isCompleted) {
+      _readyCompleter.completeError(error);
+    }
     _eventsController.addError(error, stackTrace);
     close();
   }

--- a/lib/src/directory_watcher/mac_os.dart
+++ b/lib/src/directory_watcher/mac_os.dart
@@ -87,8 +87,11 @@ class _MacOSDirectoryWatcher
     //
     // If we do receive a batch of events, [_onBatch] will ensure that these
     // futures don't fire and that the directory is re-listed.
-    Future.wait([_listDir(), _waitForBogusEvents()])
-        .then((_) => _readyCompleter.complete());
+    Future.wait([_listDir(), _waitForBogusEvents()]).then((_) {
+      if (!_readyCompleter.isCompleted) {
+        _readyCompleter.complete();
+      }
+    });
   }
 
   @override
@@ -115,7 +118,11 @@ class _MacOSDirectoryWatcher
       // Cancel the timer because bogus events only occur in the first batch, so
       // we can fire [ready] as soon as we're done listing the directory.
       _bogusEventTimer.cancel();
-      _listDir().then((_) => _readyCompleter.complete());
+      _listDir().then((_) {
+        if (!_readyCompleter.isCompleted) {
+          _readyCompleter.complete();
+        }
+      });
       return;
     }
 

--- a/lib/src/directory_watcher/polling.dart
+++ b/lib/src/directory_watcher/polling.dart
@@ -119,8 +119,8 @@ class _PollingDirectoryWatcher
       _filesToProcess.add(entity.path);
     }, onError: (Object error, StackTrace stackTrace) {
       // Guarantee that ready always completes.
-      if (!_readyCompleter.isCompleted) {
-        _readyCompleter.completeError(error);
+      if (!isReady) {
+        _readyCompleter.complete();
       }
       _events.addError(error, stackTrace);
 

--- a/lib/src/directory_watcher/polling.dart
+++ b/lib/src/directory_watcher/polling.dart
@@ -9,6 +9,7 @@ import '../async_queue.dart';
 import '../directory_watcher.dart';
 import '../resubscribable.dart';
 import '../stat.dart';
+import '../utils.dart';
 import '../watch_event.dart';
 
 /// Periodically polls a directory for changes.
@@ -122,7 +123,11 @@ class _PollingDirectoryWatcher
       if (!isReady) {
         _readyCompleter.complete();
       }
-      _events.addError(error, stackTrace);
+      if (!isDirectoryNotFoundException(error)) {
+        // It's some unknown error. Pipe it over to the event stream so the
+        // user can see it.
+        _events.addError(error, stackTrace);
+      }
 
       // When an error occurs, we end the listing normally, which has the
       // desired effect of marking all files that were in the directory as

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -92,7 +92,9 @@ class _WindowsDirectoryWatcher
     _listDir().then((_) {
       _startWatch();
       _startParentWatcher();
-      _readyCompleter.complete();
+      if (!_readyCompleter.isCompleted) {
+        _readyCompleter.complete();
+      }
     });
   }
 

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -92,7 +92,7 @@ class _WindowsDirectoryWatcher
     _listDir().then((_) {
       _startWatch();
       _startParentWatcher();
-      if (!_readyCompleter.isCompleted) {
+      if (!isReady) {
         _readyCompleter.complete();
       }
     });
@@ -430,8 +430,8 @@ class _WindowsDirectoryWatcher
   /// Emit an error, then close the watcher.
   void _emitError(Object error, StackTrace stackTrace) {
     // Guarantee that ready always completes.
-    if (!_readyCompleter.isCompleted) {
-      _readyCompleter.completeError(error);
+    if (!isReady) {
+      _readyCompleter.complete();
     }
     _eventsController.addError(error, stackTrace);
     close();

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -427,6 +427,10 @@ class _WindowsDirectoryWatcher
 
   /// Emit an error, then close the watcher.
   void _emitError(Object error, StackTrace stackTrace) {
+    // Guarantee that ready always completes.
+    if (!_readyCompleter.isCompleted) {
+      _readyCompleter.completeError(error);
+    }
     _eventsController.addError(error, stackTrace);
     close();
   }

--- a/lib/src/resubscribable.dart
+++ b/lib/src/resubscribable.dart
@@ -53,8 +53,10 @@ abstract class ResubscribableWatcher implements Watcher {
           // It's important that we complete the value of [_readyCompleter] at
           // the time [onListen] is called, as opposed to the value when
           // [watcher.ready] fires. A new completer may be created by that time.
-          await watcher.ready;
-          _readyCompleter.complete();
+          await watcher.ready.then(
+            _readyCompleter.complete,
+            onError: _readyCompleter.completeError,
+          );
         },
         onCancel: () {
           // Cancel the subscription before closing the watcher so that the

--- a/lib/src/resubscribable.dart
+++ b/lib/src/resubscribable.dart
@@ -53,10 +53,8 @@ abstract class ResubscribableWatcher implements Watcher {
           // It's important that we complete the value of [_readyCompleter] at
           // the time [onListen] is called, as opposed to the value when
           // [watcher.ready] fires. A new completer may be created by that time.
-          await watcher.ready.then(
-            _readyCompleter.complete,
-            onError: _readyCompleter.completeError,
-          );
+          await watcher.ready;
+          _readyCompleter.complete();
         },
         onCancel: () {
           // Cancel the subscription before closing the watcher so that the

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:collection';
-
 import 'dart:io';
 
 /// Returns `true` if [error] is a [FileSystemException] for a missing

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -3,18 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:collection';
-
-/// Returns `true` if [error] is a [FileSystemException] for a missing
-/// directory.
-bool isDirectoryNotFoundException(Object error) {
-  if (error is! FileSystemException) return false;
-
-  // See dartbug.com/12461 and tests/standalone/io/directory_error_test.dart.
-  var notFoundCode = Platform.operatingSystem == 'windows' ? 3 : 2;
-  return error.osError?.errorCode == notFoundCode;
-}
 
 /// Returns the union of all elements in each set in [sets].
 Set<T> unionAll<T>(Iterable<Set<T>> sets) =>

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -5,6 +5,18 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'dart:io';
+
+/// Returns `true` if [error] is a [FileSystemException] for a missing
+/// directory.
+bool isDirectoryNotFoundException(Object error) {
+  if (error is! FileSystemException) return false;
+
+  // See dartbug.com/12461 and tests/standalone/io/directory_error_test.dart.
+  var notFoundCode = Platform.operatingSystem == 'windows' ? 3 : 2;
+  return error.osError?.errorCode == notFoundCode;
+}
+
 /// Returns the union of all elements in each set in [sets].
 Set<T> unionAll<T>(Iterable<Set<T>> sets) =>
     sets.fold(<T>{}, (union, set) => union.union(set));

--- a/lib/watcher.dart
+++ b/lib/watcher.dart
@@ -42,6 +42,9 @@ abstract class Watcher {
   ///
   /// If the watcher is already monitoring, this returns an already complete
   /// future.
+  ///
+  /// This future always completes successfully as errors are provided through
+  /// the [events] stream.
   Future get ready;
 
   /// Creates a new [DirectoryWatcher] or [FileWatcher] monitoring [path],

--- a/test/ready/shared.dart
+++ b/test/ready/shared.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:test/test.dart';
 
@@ -63,15 +62,14 @@ void sharedTests() {
     expect(watcher.ready, doesNotComplete);
   });
 
-  test('completes with error if directory does not exist', () async {
+  test('completes even if directory does not exist', () async {
     var watcher = createWatcher(path: 'does/not/exist');
 
     // Subscribe to the events (else ready will never fire).
-    // ignore: unused_local_variable
     var subscription = watcher.events.listen((event) {}, onError: (error) {});
 
-    // Expected ready completes with an error.
-    await expectLater(watcher.ready, throwsA(isA<FileSystemException>()));
+    // Expect ready still completes.
+    await watcher.ready;
 
     // Now unsubscribe.
     await subscription.cancel();

--- a/test/ready/shared.dart
+++ b/test/ready/shared.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:test/test.dart';
 
@@ -60,5 +61,19 @@ void sharedTests() {
 
     // Should be back to not ready.
     expect(watcher.ready, doesNotComplete);
+  });
+
+  test('completes with error if directory does not exist', () async {
+    var watcher = createWatcher(path: 'does/not/exist');
+
+    // Subscribe to the events (else ready will never fire).
+    // ignore: unused_local_variable
+    var subscription = watcher.events.listen((event) {}, onError: (error) {});
+
+    // Expected ready completes with an error.
+    await expectLater(watcher.ready, throwsA(isA<FileSystemException>()));
+
+    // Now unsubscribe.
+    await subscription.cancel();
   });
 }


### PR DESCRIPTION
See #115.

@jakemac53

- [x] macOS: tested manually + tests, all seems to work
- [x] Linux: tested manually + tests, all seems to work
- [ ] Windows: tested manually, works, but there doesn't seem to be a windows test for `ready`.. I tried adding one, but the existing tests fail with strange vague errors ("Access is denied") and I'm not sure what the expectations are here

When errors are emitted and the stream will be closed, the ready completed is completed with that error. As far as I can see, the original code (that completes it without an error) should not also fire in this case, but if you think that's a risk we could add a condition around that to not complete if it's already completed too.

I had to also pass the error through in resubscribable for the tests to pass, and I noticed there is some additional code an emit errors _without_ closing the watcher (in children?), but I didn't touch them as I assumed in those cases the normal ready code is firing.