### PR TITLE
Add/enable Windows tests

### DIFF
--- a/test/directory_watcher/shared.dart
+++ b/test/directory_watcher/shared.dart
@@ -276,7 +276,8 @@ void sharedTests() {
         isAddEvent('new')
       ]);
     }, onPlatform: {
-      'mac-os': Skip('https://github.com/dart-lang/watcher/issues/21')
+      'mac-os': Skip('https://github.com/dart-lang/watcher/issues/21'),
+      'windows': Skip('https://github.com/dart-lang/watcher/issues/21')
     });
 
     test('emits events for many nested files added at once', () async {

--- a/test/no_subscription/windows_test.dart
+++ b/test/no_subscription/windows_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -6,7 +6,6 @@
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/windows.dart';
-import 'package:watcher/watcher.dart';
 
 import 'shared.dart';
 import '../utils.dart';
@@ -14,11 +13,5 @@ import '../utils.dart';
 void main() {
   watcherFactory = (dir) => WindowsDirectoryWatcher(dir);
 
-  group('Shared Tests:', () {
-    sharedTests();
-  });
-
-  test('DirectoryWatcher creates a WindowsDirectoryWatcher on Windows', () {
-    expect(DirectoryWatcher('.'), TypeMatcher<WindowsDirectoryWatcher>());
-  });
+  sharedTests();
 }

--- a/test/ready/windows_test.dart
+++ b/test/ready/windows_test.dart
@@ -1,4 +1,4 @@
-// Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
@@ -6,7 +6,6 @@
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/windows.dart';
-import 'package:watcher/watcher.dart';
 
 import 'shared.dart';
 import '../utils.dart';
@@ -14,11 +13,5 @@ import '../utils.dart';
 void main() {
   watcherFactory = (dir) => WindowsDirectoryWatcher(dir);
 
-  group('Shared Tests:', () {
-    sharedTests();
-  });
-
-  test('DirectoryWatcher creates a WindowsDirectoryWatcher on Windows', () {
-    expect(DirectoryWatcher('.'), TypeMatcher<WindowsDirectoryWatcher>());
-  });
+  sharedTests();
 }


### PR DESCRIPTION
These tests currently crash on Windows for me - calling `await watcher.ready` results in:

```
SocketException: OS Error: Access is denied.
, errno = 5, port = 0
```

And an entry in event viewer:

```
Faulting application name: dart.exe, version: 0.0.0.0, time stamp: 0x61a5f0de
Faulting module name: ntdll.dll, version: 10.0.19041.1288, time stamp: 0xa280d1d6
Exception code: 0xc0000005
Fault offset: 0x0000000000063416
Faulting process ID: 0x710
Faulting application start time: 0x01d80bce9da4ec85
Faulting application path: N:\Apps\Dart\nightly\bin\dart.exe
Faulting module path: C:\WINDOWS\SYSTEM32\ntdll.dll
Report ID: e34a430f-91d6-468e-afa0-9ba0ef817621
Faulting package full name: 
Faulting package-relative application ID: 
```

I'm not sure whether it's just my machine though, so @jakemac53 could you allow this to run on the bots to see if it crashes there?

(I also enabled some other tests that pass with the exception of one, which is also marked as skip for mac-os with #21 which I think is a similar issue).