### PR TITLE
Update the CI configuration; add markdown badges

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+# Dependabot configuration file.
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         sdk: [dev]
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.0
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: ${{ matrix.sdk }}
       - id: install
@@ -48,8 +48,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         sdk: [2.14.0, dev]
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.0
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: ${{ matrix.sdk }}
       - id: install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.2-dev
+# 1.0.2
 
 - Require Dart SDK >= 2.14
 - Ensure `DirectoryWatcher.ready` completes even when errors occur that close the watcher.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Require Dart SDK >= 2.14
 - Ensure `DirectoryWatcher.ready` completes even when errors occur that close the watcher.
+- Add markdown badges to the readme.
 
 # 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
+[![Dart CI](https://github.com/dart-lang/watcher/actions/workflows/test-package.yml/badge.svg)](https://github.com/dart-lang/watcher/actions/workflows/test-package.yml)
+[![pub package](https://img.shields.io/pub/v/watcher.svg)](https://pub.dev/packages/watcher)
+[![package publisher](https://img.shields.io/pub/publisher/watcher.svg)](https://pub.dev/packages/watcher/publisher)
+
 A file system watcher.
 
-It monitors changes to contents of directories and sends notifications when
-files have been added, removed, or modified.
+## What's this?
+
+`package:watcher` monitors changes to contents of directories and sends
+notifications when files have been added, removed, or modified.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,5 @@
 include: package:lints/recommended.yaml
+
 analyzer:
   strong-mode:
     implicit-casts: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,5 @@
 name: watcher
-version: 1.0.2-dev
-
+version: 1.0.2
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.


### PR DESCRIPTION
Various updates:
- update the CI configuration
- add a dependabot configuration
- add readme markdown badges
- prep for publishing - rev to a stable version
