### PR TITLE
Require Dart 2.19, use new team lints

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [2.14.0, dev]
+        sdk: [2.19.0, dev]
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.3-dev
+
+- Require Dart SDK >= 2.19
+
 # 1.0.2
 
 - Require Dart SDK >= 2.14

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,20 +1,10 @@
-include: package:lints/recommended.yaml
+include: package:dart_flutter_team_lints/analysis_options.yaml
 
 analyzer:
   language:
     strict-casts: true
-  errors:
-    todo: ignore
-    unused_import: error
-    unused_element: error
-    unused_local_variable: error
-    dead_code: error
 
 linter:
   rules:
-    # comment_references # https://github.com/dart-lang/sdk/issues/39467
-    - depend_on_referenced_packages
-    - prefer_generic_function_type_aliases
-    - prefer_typing_uninitialized_variables
-    - unnecessary_const
-    - unnecessary_new
+    - comment_references # https://github.com/dart-lang/sdk/issues/39467
+

--- a/benchmark/path_set.dart
+++ b/benchmark/path_set.dart
@@ -10,7 +10,6 @@ import 'dart:math' as math;
 
 import 'package:benchmark_harness/benchmark_harness.dart';
 import 'package:path/path.dart' as p;
-
 import 'package:watcher/src/path_set.dart';
 
 final String root = Platform.isWindows ? r'C:\root' : '/root';
@@ -31,7 +30,7 @@ abstract class PathSetBenchmark extends BenchmarkBase {
   /// Each virtual directory contains ten entries: either subdirectories or
   /// files.
   void walkTree(int depth, void Function(String) callback) {
-    void recurse(String path, remainingDepth) {
+    void recurse(String path, int remainingDepth) {
       for (var i = 0; i < 10; i++) {
         var padded = i.toString().padLeft(2, '0');
         if (remainingDepth == 0) {
@@ -100,7 +99,7 @@ class ContainsBenchmark extends PathSetBenchmark {
       if (pathSet.contains(path)) contained++;
     }
 
-    if (contained != 10000) throw 'Wrong result: $contained';
+    if (contained != 10000) throw StateError('Wrong result: $contained');
   }
 }
 
@@ -119,7 +118,7 @@ class PathsBenchmark extends PathSetBenchmark {
       count++;
     }
 
-    if (count != 10000) throw 'Wrong result: $count';
+    if (count != 10000) throw StateError('Wrong result: $count');
   }
 }
 

--- a/example/watch.dart
+++ b/example/watch.dart
@@ -15,7 +15,5 @@ void main(List<String> arguments) {
   }
 
   var watcher = DirectoryWatcher(p.absolute(arguments[0]));
-  watcher.events.listen((event) {
-    print(event);
-  });
+  watcher.events.listen(print);
 }

--- a/lib/src/directory_watcher/mac_os.dart
+++ b/lib/src/directory_watcher/mac_os.dart
@@ -160,9 +160,7 @@ class _MacOSDirectoryWatcher
           subscription.onDone(() {
             _listSubscriptions.remove(subscription);
           });
-          subscription.onError((Object e, StackTrace stackTrace) {
-            _emitError(e, stackTrace);
-          });
+          subscription.onError(_emitError);
           _listSubscriptions.add(subscription);
         } else if (event is FileSystemModifyEvent) {
           assert(!event.isDirectory);
@@ -294,7 +292,7 @@ class _MacOSDirectoryWatcher
         return ConstructableFileSystemModifyEvent(
             batch.first.path, isDir, false);
       default:
-        throw 'unreachable';
+        throw StateError('unreachable');
     }
   }
 

--- a/lib/src/directory_watcher/windows.dart
+++ b/lib/src/directory_watcher/windows.dart
@@ -155,8 +155,7 @@ class _WindowsDirectoryWatcher
 
   void _onEvent(FileSystemEvent event) {
     assert(isReady);
-    final batcher =
-        _eventBatchers.putIfAbsent(event.path, () => _EventBatcher());
+    final batcher = _eventBatchers.putIfAbsent(event.path, _EventBatcher.new);
     batcher.addEvent(event, () {
       _eventBatchers.remove(event.path);
       _onBatch(batcher.events);
@@ -316,7 +315,7 @@ class _WindowsDirectoryWatcher
       case FileSystemEvent.move:
         return null;
       default:
-        throw 'unreachable';
+        throw StateError('unreachable');
     }
   }
 
@@ -397,6 +396,7 @@ class _WindowsDirectoryWatcher
         _eventsController.addError(error, stackTrace);
         _startWatch();
       } else {
+        // ignore: only_throw_errors
         throw error;
       }
     });

--- a/lib/src/path_set.dart
+++ b/lib/src/path_set.dart
@@ -33,7 +33,7 @@ class PathSet {
     var parts = p.split(path);
     var entry = _entries;
     for (var part in parts) {
-      entry = entry.contents.putIfAbsent(part, () => _Entry());
+      entry = entry.contents.putIfAbsent(part, _Entry.new);
     }
 
     entry.isExplicit = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,20 @@
 name: watcher
-version: 1.0.2
+version: 1.0.3-dev
 description: >-
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.
 repository: https://github.com/dart-lang/watcher
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: '>=2.19.0 <3.0.0'
 
 dependencies:
   async: ^2.5.0
   path: ^1.8.0
 
 dev_dependencies:
-  lints: ^1.0.0
   benchmark_harness: ^2.0.0
+  dart_flutter_team_lints: ^1.0.0
   test: ^1.16.0
   test_descriptor: ^2.0.0
 

--- a/test/custom_watcher_factory_test.dart
+++ b/test/custom_watcher_factory_test.dart
@@ -50,9 +50,12 @@ void main() {
 
   test('registering twice throws', () async {
     expect(
-        () => registerCustomWatcher(memFsFactoryId,
-            (_, {pollingDelay}) => throw 0, (_, {pollingDelay}) => throw 0),
-        throwsA(isA<ArgumentError>()));
+      () => registerCustomWatcher(
+          memFsFactoryId,
+          (_, {pollingDelay}) => throw UnimplementedError(),
+          (_, {pollingDelay}) => throw UnimplementedError()),
+      throwsA(isA<ArgumentError>()),
+    );
   });
 
   test('finding two applicable factories throws', () async {

--- a/test/directory_watcher/linux_test.dart
+++ b/test/directory_watcher/linux_test.dart
@@ -3,16 +3,17 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('linux')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/linux.dart';
 import 'package:watcher/watcher.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => LinuxDirectoryWatcher(dir);
+  watcherFactory = LinuxDirectoryWatcher.new;
 
   sharedTests();
 

--- a/test/directory_watcher/mac_os_test.dart
+++ b/test/directory_watcher/mac_os_test.dart
@@ -3,16 +3,17 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('mac-os')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/mac_os.dart';
 import 'package:watcher/watcher.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => MacOSDirectoryWatcher(dir);
+  watcherFactory = MacOSDirectoryWatcher.new;
 
   sharedTests();
 

--- a/test/directory_watcher/polling_test.dart
+++ b/test/directory_watcher/polling_test.dart
@@ -5,8 +5,8 @@
 import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
   // Use a short delay to make the tests run quickly.

--- a/test/directory_watcher/shared.dart
+++ b/test/directory_watcher/shared.dart
@@ -278,7 +278,6 @@ void sharedTests() {
         isAddEvent('new')
       ]);
     }, onPlatform: {
-      'mac-os': Skip('https://github.com/dart-lang/watcher/issues/21'),
       'windows': Skip('https://github.com/dart-lang/watcher/issues/21')
     });
 

--- a/test/directory_watcher/windows_test.dart
+++ b/test/directory_watcher/windows_test.dart
@@ -3,20 +3,19 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('windows')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/windows.dart';
 import 'package:watcher/watcher.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => WindowsDirectoryWatcher(dir);
+  watcherFactory = WindowsDirectoryWatcher.new;
 
-  group('Shared Tests:', () {
-    sharedTests();
-  });
+  group('Shared Tests:', sharedTests);
 
   test('DirectoryWatcher creates a WindowsDirectoryWatcher on Windows', () {
     expect(DirectoryWatcher('.'), TypeMatcher<WindowsDirectoryWatcher>());

--- a/test/file_watcher/native_test.dart
+++ b/test/file_watcher/native_test.dart
@@ -3,15 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('linux || mac-os')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/file_watcher/native.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (file) => NativeFileWatcher(file);
+  watcherFactory = NativeFileWatcher.new;
 
   setUp(() {
     writeFile('file.txt');

--- a/test/file_watcher/polling_test.dart
+++ b/test/file_watcher/polling_test.dart
@@ -3,12 +3,13 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('linux || mac-os')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
   watcherFactory = (file) =>

--- a/test/no_subscription/linux_test.dart
+++ b/test/no_subscription/linux_test.dart
@@ -3,15 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('linux')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/linux.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => LinuxDirectoryWatcher(dir);
+  watcherFactory = LinuxDirectoryWatcher.new;
 
   sharedTests();
 }

--- a/test/no_subscription/mac_os_test.dart
+++ b/test/no_subscription/mac_os_test.dart
@@ -3,16 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('mac-os')
-@Skip('Flaky due to sdk#23877')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/mac_os.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => MacOSDirectoryWatcher(dir);
+  watcherFactory = MacOSDirectoryWatcher.new;
 
   sharedTests();
 }

--- a/test/no_subscription/polling_test.dart
+++ b/test/no_subscription/polling_test.dart
@@ -4,11 +4,11 @@
 
 import 'package:watcher/watcher.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => PollingDirectoryWatcher(dir);
+  watcherFactory = PollingDirectoryWatcher.new;
 
   sharedTests();
 }

--- a/test/no_subscription/windows_test.dart
+++ b/test/no_subscription/windows_test.dart
@@ -3,15 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('windows')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/windows.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => WindowsDirectoryWatcher(dir);
+  watcherFactory = WindowsDirectoryWatcher.new;
 
   sharedTests();
 }

--- a/test/ready/linux_test.dart
+++ b/test/ready/linux_test.dart
@@ -3,15 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('linux')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/linux.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => LinuxDirectoryWatcher(dir);
+  watcherFactory = LinuxDirectoryWatcher.new;
 
   sharedTests();
 }

--- a/test/ready/mac_os_test.dart
+++ b/test/ready/mac_os_test.dart
@@ -3,15 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('mac-os')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/mac_os.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => MacOSDirectoryWatcher(dir);
+  watcherFactory = MacOSDirectoryWatcher.new;
 
   sharedTests();
 }

--- a/test/ready/polling_test.dart
+++ b/test/ready/polling_test.dart
@@ -4,11 +4,11 @@
 
 import 'package:watcher/watcher.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => PollingDirectoryWatcher(dir);
+  watcherFactory = PollingDirectoryWatcher.new;
 
   sharedTests();
 }

--- a/test/ready/shared.dart
+++ b/test/ready/shared.dart
@@ -42,9 +42,12 @@ void sharedTests() {
 
     // Ensure ready completes immediately
     expect(
-        watcher.ready.timeout(Duration(milliseconds: 0),
-            onTimeout: () => throw 'Does not complete immedately'),
-        completes);
+      watcher.ready.timeout(
+        Duration(milliseconds: 0),
+        onTimeout: () => throw StateError('Does not complete immedately'),
+      ),
+      completes,
+    );
 
     await subscription.cancel();
   });

--- a/test/ready/windows_test.dart
+++ b/test/ready/windows_test.dart
@@ -3,15 +3,16 @@
 // BSD-style license that can be found in the LICENSE file.
 
 @TestOn('windows')
+library;
 
 import 'package:test/test.dart';
 import 'package:watcher/src/directory_watcher/windows.dart';
 
-import 'shared.dart';
 import '../utils.dart';
+import 'shared.dart';
 
 void main() {
-  watcherFactory = (dir) => WindowsDirectoryWatcher(dir);
+  watcherFactory = WindowsDirectoryWatcher.new;
 
   sharedTests();
 }


### PR DESCRIPTION
Enable some tests that now seem to be passing on mac
