### PR TITLE
Enable file watcher tests on Windows

### DIFF
--- a/test/file_watcher/polling_test.dart
+++ b/test/file_watcher/polling_test.dart
@@ -2,9 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-@TestOn('linux || mac-os')
-library;
-
 import 'package:test/test.dart';
 import 'package:watcher/watcher.dart';
 

--- a/test/file_watcher/shared.dart
+++ b/test/file_watcher/shared.dart
@@ -65,4 +65,9 @@ void sharedTests() {
     await Future<void>.delayed(const Duration(milliseconds: 10));
     await sub.cancel();
   });
+
+  test('ready completes even if file does not exist', () async {
+    // startWatcher awaits 'ready'
+    await startWatcher(path: 'foo/bar/baz');
+  });
 }

--- a/test/ready/shared.dart
+++ b/test/ready/shared.dart
@@ -69,7 +69,7 @@ void sharedTests() {
     expect(watcher.ready, doesNotComplete);
   });
 
-  test('completes even if directory does not exist', () async {
+  test('ready completes even if directory does not exist', () async {
     var watcher = createWatcher(path: 'does/not/exist');
 
     // Subscribe to the events (else ready will never fire).


### PR DESCRIPTION
While trying to track down https://github.com/dart-lang/sdk/issues/54116 (which looks like the `ready` event not firing), I noticed these file watcher tests were skipped for Windows.

They all pass (at least for me locally), so I don't think they should be skipped.

I also added a new test for what I thought was the cause of https://github.com/dart-lang/sdk/issues/54116 but it's also passing, so I need to do some more debugging of that 🤷‍♂️

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
