### PR TITLE
Fix PollingFileWatcher.ready for files that don't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.1-wip
 
-- Ensure `FileWatcher.ready` completes for files that do not exist.
+- Ensure `PollingFileWatcher.ready` completes for files that do not exist.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.1.1-wip
 
+- Ensure `FileWatcher.ready` completes for files that do not exist.
+
 ## 1.1.0
 
 - Require Dart SDK >= 3.0.0

--- a/lib/src/file_watcher/polling.dart
+++ b/lib/src/file_watcher/polling.dart
@@ -61,7 +61,7 @@ class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {
     var pathExists = await File(path).exists();
     if (_eventsController.isClosed) return;
 
-    if (!_isFirstPoll && !pathExists) {
+    if (_lastModified != null && !pathExists) {
       _eventsController.add(WatchEvent(ChangeType.REMOVE, path));
       unawaited(close());
       return;

--- a/lib/src/file_watcher/polling.dart
+++ b/lib/src/file_watcher/polling.dart
@@ -37,12 +37,6 @@ class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {
   /// The timer that controls polling.
   late final Timer _timer;
 
-  /// Track whether the next [_poll] is the first.
-  ///
-  /// We cannot just check [_lastModified] is null, because that is a valid
-  /// state for a file that does not exist.
-  var _isFirstPoll = true;
-
   /// The previous modification time of the file.
   ///
   /// `null` indicates the file does not (or did not on the last poll) exist.
@@ -78,12 +72,11 @@ class _PollingFileWatcher implements FileWatcher, ManuallyClosedWatcher {
     }
     if (_eventsController.isClosed) return;
 
-    if (_isFirstPoll) {
+    if (!isReady) {
       // If this is the first poll, don't emit an event, just set the last mtime
       // and complete the completer.
       _lastModified = modified;
       _readyCompleter.complete();
-      _isFirstPoll = false;
       return;
     }
 

--- a/lib/src/stat.dart
+++ b/lib/src/stat.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 /// A function that takes a file path and returns the last modified time for
 /// the file at that path.
-typedef MockTimeCallback = DateTime Function(String path);
+typedef MockTimeCallback = DateTime? Function(String path);
 
 MockTimeCallback? _mockTimeCallback;
 

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -256,7 +256,6 @@ void renameDir(String from, String to) {
   final knownFilePaths = _mockFileModificationTimes.keys.toList();
   for (final filePath in knownFilePaths) {
     if (p.isWithin(from, filePath)) {
-      print('moving $filePath to ${filePath.replaceAll(from, to)}');
       _mockFileModificationTimes[filePath.replaceAll(from, to)] =
           _mockFileModificationTimes[filePath]!;
       _mockFileModificationTimes.remove(filePath);

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -195,6 +195,11 @@ Future expectRemoveEvent(String path) =>
 Future allowModifyEvent(String path) =>
     _expectOrCollect(mayEmit(isWatchEvent(ChangeType.MODIFY, path)));
 
+/// Track a fake timestamp to be used when writing files. This always increases
+/// so that files that are deleted and re-created do not have their timestamp
+/// set back to a previously used value.
+int _nextTimestamp = 1;
+
 /// Schedules writing a file in the sandbox at [path] with [contents].
 ///
 /// If [contents] is omitted, creates an empty file. If [updateModified] is
@@ -216,14 +221,15 @@ void writeFile(String path, {String? contents, bool? updateModified}) {
   if (updateModified) {
     path = p.normalize(path);
 
-    _mockFileModificationTimes.update(path, (value) => value + 1,
-        ifAbsent: () => 1);
+    _mockFileModificationTimes[path] = _nextTimestamp++;
   }
 }
 
 /// Schedules deleting a file in the sandbox at [path].
 void deleteFile(String path) {
   File(p.join(d.sandbox, path)).deleteSync();
+
+  _mockFileModificationTimes.remove(path);
 }
 
 /// Schedules renaming a file in the sandbox from [from] to [to].
@@ -245,6 +251,17 @@ void createDir(String path) {
 /// Schedules renaming a directory in the sandbox from [from] to [to].
 void renameDir(String from, String to) {
   Directory(p.join(d.sandbox, from)).renameSync(p.join(d.sandbox, to));
+
+  // Migrate timestamps for any files in this folder.
+  final knownFilePaths = _mockFileModificationTimes.keys.toList();
+  for (final filePath in knownFilePaths) {
+    if (p.isWithin(from, filePath)) {
+      print('moving $filePath to ${filePath.replaceAll(from, to)}');
+      _mockFileModificationTimes[filePath.replaceAll(from, to)] =
+          _mockFileModificationTimes[filePath]!;
+      _mockFileModificationTimes.remove(filePath);
+    }
+  }
 }
 
 /// Schedules deleting a directory in the sandbox at [path].

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -67,7 +67,7 @@ Future<void> startWatcher({String? path}) async {
         'Path is not in the sandbox: $path not in ${d.sandbox}');
 
     var mtime = _mockFileModificationTimes[normalized];
-    return DateTime.fromMillisecondsSinceEpoch(mtime ?? 0);
+    return mtime != null ? DateTime.fromMillisecondsSinceEpoch(mtime) : null;
   });
 
   // We want to wait until we're ready *after* we subscribe to the watcher's


### PR DESCRIPTION
There were a few issues here:

- FileWatcher.ready never fired for files that don't exist because of logic inside FileWatcher existing early if the modification time was `null`
- The test I recently added trying to catch this was incorrectly passing because the mock timestamp code was set so that files that had not been created would return a 0-mtime whereas in the real implementation they return `null`

So this change

a) updates the mock to return `null` for uncreated files (to match the real implementation) which breaks a bunch of tests

b) fixes those tests by updating FileWatcher._poll() to handle `null` mtime separately from being the first poll.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
